### PR TITLE
[Feature] Support multi-stream vertex layout (#4)

### DIFF
--- a/app/ExampleLayer.cpp
+++ b/app/ExampleLayer.cpp
@@ -19,8 +19,6 @@ struct Vertex {
 };
 
 std::unique_ptr<ExampleLayer> ExampleLayer::Create(core::Application* app) {
-    using core::render::Vertex;
-
     core::render::Device* device = app->GetDevice();
     core::render::PipelineManager* pipelineManager = app->GetPipelineManager();
     core::AssetManager* assetManager = app->GetAssetManager();
@@ -30,13 +28,6 @@ std::unique_ptr<ExampleLayer> ExampleLayer::Create(core::Application* app) {
 
     auto shader = shaderManager->GetStandardShader();
 
-    core::render::PipelineDesc pipelineDesc{
-        .shaderAsset = shader,
-        .vertexType = core::render::VertexType::StandardMesh,
-        .blendState = wgx::BlendState::kReplace,
-    };
-    pipelineManager->GetRenderPipeline(pipelineDesc);
-
     auto config = device->GetSurfaceConfig();
     auto proj = common::Projection::Perspective(45, config.width, config.height, 0.1, 100.0);
     common::GameCamera gameCamera{glm::vec3(0.F, 0.F, 0.F), 0.F, 0.F, proj};
@@ -44,12 +35,11 @@ std::unique_ptr<ExampleLayer> ExampleLayer::Create(core::Application* app) {
     loader::GLTFLoader loader{
         app->GetAssetManager(),
         app->GetTextureManager(),
-         app->GetMaterialManager(),
+        app->GetMaterialManager(),
         app->GetMeshManager(),
     };
 
-    return std::unique_ptr<ExampleLayer>(
-        new ExampleLayer(app, device, gameCamera,  loader));
+    return std::unique_ptr<ExampleLayer>(new ExampleLayer(app, device, gameCamera, loader));
 }
 
 void ExampleLayer::OnAttach() {
@@ -64,21 +54,33 @@ void ExampleLayer::OnRender(core::render::FrameContext& context) {
     auto& d = m_device->GetDeivce();
     auto am = m_app->GetAssetManager();
     auto modelView = am->GetModel(m_modelHandle);
+    auto pm = m_app->GetPipelineManager();
 
     auto cameraData = m_gameCamera.GetCameraUniformData();
     context.SetCameraData(cameraData);
 
     for (auto& renderUnit : modelView->renderUnits) {
         auto meshView = am->GetMesh(renderUnit.meshHandle);
-        auto mesh = meshView->submeshInfos[renderUnit.subMeshIndex];
+        auto& subMesh = meshView->GetSubMeshInfors(renderUnit.subMeshIndex);
 
         auto modelMatrix = renderUnit.modelMatrix;
         auto material = am->GetMaterial(renderUnit.materialHandle);
+        auto shader = material->GetShader();
+
+        wgpu::RenderPipeline pipeline = pm->GetRenderPipeline(
+            core::render::PipelineDesc{.shaderAsset = shader,
+                                       .vertexEntry = "vertexMain",
+                                       .fragmentEntry = "fragmentMain",
+                                       .vertexState = meshView->GetVertexState(subMesh.stateIndex)});
 
         core::render::RenderPacket packet{
+            .pipeline = pipeline,
             .vertexBuffer = meshView->vertexBuffer,
             .indexBuffer = meshView->indexBuffer,
-            .indexCount = mesh.indexCount,
+            .bufferRanges =
+                meshView->GetBufferRanges(subMesh.bufferRangeStart, subMesh.bufferRangeCount),
+            .indexStart = subMesh.indexStart,
+            .indexCount = subMesh.indexCount,
             .material = material,
         };
         context.Submit(packet);

--- a/app/ExampleLayer.cpp
+++ b/app/ExampleLayer.cpp
@@ -60,7 +60,7 @@ void ExampleLayer::OnRender(core::render::FrameContext& context) {
 
     for (auto& renderUnit : modelView->renderUnits) {
         auto meshView = am->GetMesh(renderUnit.meshHandle);
-        auto& subMesh = meshView->GetSubMeshInfors(renderUnit.subMeshIndex);
+        auto& subMesh = meshView->GetSubMeshInfos(renderUnit.subMeshIndex);
 
         auto material = am->GetMaterial(renderUnit.materialHandle);
 

--- a/app/ExampleLayer.cpp
+++ b/app/ExampleLayer.cpp
@@ -51,7 +51,6 @@ void ExampleLayer::OnAttach() {
 }
 
 void ExampleLayer::OnRender(core::render::FrameContext& context) {
-    auto& d = m_device->GetDeivce();
     auto am = m_app->GetAssetManager();
     auto modelView = am->GetModel(m_modelHandle);
     auto pm = m_app->GetPipelineManager();
@@ -63,9 +62,7 @@ void ExampleLayer::OnRender(core::render::FrameContext& context) {
         auto meshView = am->GetMesh(renderUnit.meshHandle);
         auto& subMesh = meshView->GetSubMeshInfors(renderUnit.subMeshIndex);
 
-        auto modelMatrix = renderUnit.modelMatrix;
         auto material = am->GetMaterial(renderUnit.materialHandle);
-        auto shader = material->GetShader();
 
         core::render::PipelineDesc desc =
             material->GetPipelineDesc(meshView->GetVertexState(subMesh.stateIndex));

--- a/app/ExampleLayer.cpp
+++ b/app/ExampleLayer.cpp
@@ -67,11 +67,10 @@ void ExampleLayer::OnRender(core::render::FrameContext& context) {
         auto material = am->GetMaterial(renderUnit.materialHandle);
         auto shader = material->GetShader();
 
-        wgpu::RenderPipeline pipeline = pm->GetRenderPipeline(
-            core::render::PipelineDesc{.shaderAsset = shader,
-                                       .vertexEntry = "vertexMain",
-                                       .fragmentEntry = "fragmentMain",
-                                       .vertexState = meshView->GetVertexState(subMesh.stateIndex)});
+        core::render::PipelineDesc desc =
+            material->GetPipelineDesc(meshView->GetVertexState(subMesh.stateIndex));
+
+        wgpu::RenderPipeline pipeline = pm->GetRenderPipeline(desc);
 
         core::render::RenderPacket packet{
             .pipeline = pipeline,

--- a/app/ModelLoader.cpp
+++ b/app/ModelLoader.cpp
@@ -34,7 +34,7 @@ std::expected<core::Handle, core::Error> loader::GLTFLoader::LoadModel(
 
         auto meshView = m_meshManager->GetMesh(meshHandle);
 
-        for (size_t i = 0; i < meshView->submeshInfos.size(); ++i) {
+        for (size_t i = 0; i < meshView->GetSubMeshInfors().size(); ++i) {
             core::render::RenderUnit renderUnit;
             renderUnit.meshHandle = meshHandle;
             renderUnit.subMeshIndex = static_cast<uint32_t>(i);

--- a/app/ShaderLoader.cpp
+++ b/app/ShaderLoader.cpp
@@ -8,6 +8,6 @@ std::expected<core::Handle, core::Error> loader::ShaderLoader::LoadShader(const 
         return std::unexpected(resultOrError.error());
     }
 
-    return m_shaderManager->LoadShader(resultOrError.value());
+    return m_shaderManager->LoadShader(std::move(resultOrError.value()));
 }
 }  // namespace loader

--- a/cmake/ShaderCompiler.cmake
+++ b/cmake/ShaderCompiler.cmake
@@ -1,37 +1,32 @@
 function(add_shader_asset)
     set(options)
     set(oneValueArgs TARGET INPUT ENTRY OUTPUT)
-    set(multiValueArgs INCLUDES) # 여러 개의 경로를 받을 수 있음
+    set(multiValueArgs INCLUDES) 
     cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    # [수정 1] BAKER_TOOL 타겟 수정
     set(BAKER_TOOL $<TARGET_FILE:shaderCompiler>)
 
-    # [수정 2] INCLUDES 리스트를 CLI 인자 포맷(-I path -I path ...)으로 변환
     set(INCLUDE_FLAGS "")
     foreach(INC_PATH ${ARG_INCLUDES})
         list(APPEND INCLUDE_FLAGS "-I" "${INC_PATH}")
     endforeach()
 
-    # [추가] ENTRY 옵션이 있는지 확인하고 조건부로 플래그 생성
     set(ENTRY_FLAG "")
     if(ARG_ENTRY)
         list(APPEND ENTRY_FLAG "-e" "${ARG_ENTRY}")
-        # 또는 set(ENTRY_FLAG "-e" "${ARG_ENTRY}") 도 동일하게 작동합니다.
     endif()
 
     add_custom_command(
         OUTPUT ${ARG_OUTPUT}
         COMMAND ${BAKER_TOOL} 
             -i ${ARG_INPUT} 
-            ${ENTRY_FLAG}       # [수정됨] 값이 없으면 빈 공간으로 무시됨
+            ${ENTRY_FLAG}
             -o ${ARG_OUTPUT}
             ${INCLUDE_FLAGS}  
         MAIN_DEPENDENCY ${ARG_INPUT}
-        DEPENDS shaderCompiler # 툴이 먼저 빌드되어야 함
+        DEPENDS shaderCompiler
         COMMENT "Baking Shader: ${ARG_INPUT} -> ${ARG_OUTPUT}"
     )
 
-    # 타겟(게임/에디터)이 이 에셋 파일에 의존하도록 설정
     target_sources(${ARG_TARGET} PRIVATE ${ARG_OUTPUT})
 endfunction()

--- a/cmake/ShaderCompiler.cmake
+++ b/cmake/ShaderCompiler.cmake
@@ -5,7 +5,6 @@ function(add_shader_asset)
     cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     # [수정 1] BAKER_TOOL 타겟 수정
-    # shaderCompiler는 '라이브러리'입니다. 실행 파일인 'ShaderBaker'를 가리켜야 합니다.
     set(BAKER_TOOL $<TARGET_FILE:shaderCompiler>)
 
     # [수정 2] INCLUDES 리스트를 CLI 인자 포맷(-I path -I path ...)으로 변환
@@ -14,13 +13,20 @@ function(add_shader_asset)
         list(APPEND INCLUDE_FLAGS "-I" "${INC_PATH}")
     endforeach()
 
+    # [추가] ENTRY 옵션이 있는지 확인하고 조건부로 플래그 생성
+    set(ENTRY_FLAG "")
+    if(ARG_ENTRY)
+        list(APPEND ENTRY_FLAG "-e" "${ARG_ENTRY}")
+        # 또는 set(ENTRY_FLAG "-e" "${ARG_ENTRY}") 도 동일하게 작동합니다.
+    endif()
+
     add_custom_command(
         OUTPUT ${ARG_OUTPUT}
         COMMAND ${BAKER_TOOL} 
             -i ${ARG_INPUT} 
-            -e ${ARG_ENTRY} 
+            ${ENTRY_FLAG}       # [수정됨] 값이 없으면 빈 공간으로 무시됨
             -o ${ARG_OUTPUT}
-            ${INCLUDE_FLAGS}  # [수정 3] 변환된 인자 추가
+            ${INCLUDE_FLAGS}  
         MAIN_DEPENDENCY ${ARG_INPUT}
         DEPENDS shaderCompiler # 툴이 먼저 빌드되어야 함
         COMMENT "Baking Shader: ${ARG_INPUT} -> ${ARG_OUTPUT}"

--- a/common/Common.h
+++ b/common/Common.h
@@ -74,6 +74,33 @@ constexpr PropertyId ToPropertyID(std::string_view name) {
     return hash;
 }
 
+enum class Semantic {
+    Position,
+    Normal,
+    Tangent,
+    Color0,
+    Color1,
+    Color2,
+    Color3,
+    TexCoord0,
+    TexCoord1,
+    TexCoord2,
+    TexCoord3,
+    TexCoord4,
+    TexCoord5,
+    TexCoord6,
+    TexCoord7,
+
+    Custom0,
+    Custom1,
+    Custom2,
+    Custom3,
+
+    Undefined = 255
+};
+
+Semantic NameToSemantic(const std::string& name, uint32_t index);
+
 constexpr uint32_t kSetNumberGlobal = 0;
 constexpr uint32_t kSetNumberMaterial = 1;
 constexpr uint32_t kSetNumberInstance = 2;

--- a/common/MeshAssetFormat.h
+++ b/common/MeshAssetFormat.h
@@ -1,31 +1,77 @@
 #pragma once
 
 #include <glm/glm.hpp>
+#include <array>
 
 #include "Common.h"
 
 namespace core {
 
-    
-struct Vertex {
-    glm::vec3 position;
-    glm::vec3 normal;
-    glm::vec2 uv;
-    glm::vec4 tangent;
-};
-
-enum class VertexType {
-    None = 0,
-    StandardMesh = 1,
-};
-
 struct MeshAssetFormat {
-    struct SubMeshInfo {
-        uint32_t indexCount = 0;
-        uint32_t baseIndexLocation = 0;
-        uint32_t baseVertexLocation = 0;
-        VertexType vertexType = VertexType::None;
+    inline constexpr static uint32_t kInvalidIndex = -1;
+
+    enum class VertexFormat : uint8_t { 
+        Float32,
+        Float32x2,
+        Float32x3,
+        Float32x4,
+        Undefined = 255 };
+
+    enum class StepMode : uint8_t { Vertex, Instance, Undefined = 255 };
+
+    struct MeshAttribute {
+        VertexFormat format;
+        Semantic semantic;
+        uint64_t offset;
+
+        bool operator==(const MeshAttribute&) const = default;
     };
+
+    struct MeshBufferSlot {
+        StepMode stepMode;
+        uint32_t stride;
+        uint8_t attributeCount = 0;
+        std::array<MeshAttribute, 8> attributes = {};
+
+        bool operator==(const MeshBufferSlot&) const = default;
+    };
+
+    struct MeshVertexState {
+        uint8_t slotCount = 0;
+        std::array<MeshBufferSlot, 4> bufferSlots = {};
+
+        bool operator==(const MeshVertexState&) const = default;
+    };
+
+    struct BufferRange {
+        uint32_t offset;
+        uint32_t size;
+    };
+
+    struct SubMeshInfo {
+        uint32_t indexCount;
+        uint32_t indexStart;
+        uint32_t stateIndex;
+        uint32_t bufferRangeStart;  // span 대신 시작 인덱스
+        uint32_t bufferRangeCount;
+    };
+
+    static constexpr size_t GetVertexFormatSize(VertexFormat format) {
+        switch (format) {
+            case VertexFormat::Float32x2:
+                return 8;
+            case VertexFormat::Float32x3:
+                return 12;
+            case VertexFormat::Float32x4:
+                return 16;
+            default:
+                assert(false && "Unknown vertex format size");
+                return 0;
+        }
+    }
+
+    std::vector<MeshVertexState> states;
+    std::vector<BufferRange> bufferRanges;
     std::vector<SubMeshInfo> subMeshes;
     std::vector<uint32_t> indexData;
     std::vector<std::byte> vertexData;

--- a/common/MeshAssetFormat.h
+++ b/common/MeshAssetFormat.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <glm/glm.hpp>
 #include <array>
+#include <glm/glm.hpp>
 
 #include "Common.h"
 
@@ -10,12 +10,7 @@ namespace core {
 struct MeshAssetFormat {
     inline constexpr static uint32_t kInvalidIndex = -1;
 
-    enum class VertexFormat : uint8_t { 
-        Float32,
-        Float32x2,
-        Float32x3,
-        Float32x4,
-        Undefined = 255 };
+    enum class VertexFormat : uint8_t { Float32, Float32x2, Float32x3, Float32x4, Undefined = 255 };
 
     enum class StepMode : uint8_t { Vertex, Instance, Undefined = 255 };
 
@@ -64,7 +59,7 @@ struct MeshAssetFormat {
         uint32_t indexCount;
         uint32_t indexStart;
         uint32_t stateIndex;
-        uint32_t bufferRangeStart;  // span 대신 시작 인덱스
+        uint32_t bufferRangeStart;
         uint32_t bufferRangeCount;
     };
 

--- a/common/MeshAssetFormat.h
+++ b/common/MeshAssetFormat.h
@@ -41,6 +41,18 @@ struct MeshAssetFormat {
         std::array<MeshBufferSlot, 4> bufferSlots = {};
 
         bool operator==(const MeshVertexState&) const = default;
+
+        bool HasAttribute(Semantic semantic) const {
+            for (uint8_t i = 0; i < slotCount; ++i) {
+                const auto& slot = bufferSlots[i];
+                for (uint8_t j = 0; j < slot.attributeCount; ++j) {
+                    if (slot.attributes[j].semantic == semantic) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
     };
 
     struct BufferRange {

--- a/common/ShaderAssetFormat.cpp
+++ b/common/ShaderAssetFormat.cpp
@@ -2,15 +2,12 @@
 
 namespace core {
 
-
 std::expected<ShaderAssetFormat, Error> core::ShaderAssetFormat::LoadFromMemory(
     std::span<const uint8_t> memory) {
     using Header = ShaderAssetFormat::Header;
     using Binding = ShaderAssetFormat::Binding;
 
     constexpr size_t HeaderSize = sizeof(Header);
-    constexpr size_t BindingsOffset = HeaderSize;
-    constexpr size_t BindingsStride = sizeof(Binding);
     const uint8_t* ptr = memory.data();
 
     ShaderAssetFormat shaderAsset;
@@ -31,26 +28,76 @@ std::expected<ShaderAssetFormat, Error> core::ShaderAssetFormat::LoadFromMemory(
     if (header.version != ShaderAssetFormat::SHADER_ASSET_VERSION) {
         return std::unexpected(Error::AssetParsing(
             std::format("Unsupported Version: version {} is not supported (current: {}).",
-            header.version, ShaderAssetFormat::SHADER_ASSET_VERSION)));
+                        header.version, ShaderAssetFormat::SHADER_ASSET_VERSION)));
     }
+    const size_t parametersOffset = header.parameterOffset;
+    const size_t bindingsOffset = header.bindingOffset;
+    const size_t variablesOffset = header.variableOffset;
+    const size_t entryPointsOffset = header.entryPointOffset;
+    const size_t codeOffset = header.shaderOffset;
+    const size_t nameTableOffset = header.nameTableOffset;
+    const size_t totalSize = nameTableOffset + header.nameTableSize;
 
-    const size_t CodeOffset = BindingsOffset + BindingsStride * header.bindingCount;
-    const size_t totalSize = CodeOffset + header.shaderSize;
     if (memory.size() < totalSize) {
         return std::unexpected(Error::AssetParsing(
             "Corrupted Asset: actual data size does not match header description"));
     }
 
+    if (header.parameterCount > 0) {
+        shaderAsset.parameters.resize(header.parameterCount);
+        std::memcpy(shaderAsset.parameters.data(), ptr + parametersOffset,
+                    sizeof(ShaderParameter) * header.parameterCount);
+    }
+
     if (header.bindingCount > 0) {
         shaderAsset.bindings.resize(header.bindingCount);
+        std::memcpy(shaderAsset.bindings.data(), ptr + bindingsOffset,
+                    sizeof(Binding) * header.bindingCount);
+    }
 
-        std::memcpy(shaderAsset.bindings.data(), ptr + BindingsOffset,
-                    BindingsStride * header.bindingCount);
+    if (header.variableCount > 0) {
+        shaderAsset.variables.resize(header.variableCount);
+        std::memcpy(shaderAsset.variables.data(), ptr + variablesOffset,
+                    sizeof(Variable) * header.shaderSize);
+    }
+
+    if (header.entryPointCount > 0) {
+        shaderAsset.entryPoints.resize(header.entryPointCount);
+        std::memcpy(shaderAsset.entryPoints.data(), ptr + entryPointsOffset,
+                    sizeof(EntryPoint) * header.entryPointCount);
     }
 
     if (header.shaderSize > 0) {
         shaderAsset.code.resize(header.shaderSize);
-        std::memcpy(shaderAsset.code.data(), ptr + CodeOffset, header.shaderSize);
+        std::memcpy(shaderAsset.code.data(), ptr + codeOffset, header.shaderSize);
+    }
+
+    if (header.indexCount > 0) {
+        shaderAsset.indices.resize(header.indexCount);
+        std::memcpy(shaderAsset.indices.data(), ptr + header.indexOffset,
+                    header.indexCount * sizeof(uint32_t));
+    }
+
+    shaderAsset.tokens;
+    if (header.nameTableSize > 0) {
+        shaderAsset.nameTableData.resize(header.nameTableSize);
+        std::memcpy(shaderAsset.nameTableData.data(), ptr + nameTableOffset, header.nameTableSize);
+        std::string_view view(shaderAsset.nameTableData);
+
+        size_t start = 0;
+        while (start < view.size()) {
+            size_t end = view.find('\0', start);
+
+            if (end == std::string_view::npos) {
+                end = view.size();
+            }
+
+            if (end > start) {
+                shaderAsset.tokens.push_back(view.substr(start, end - start));
+            }
+
+            start = end + 1;
+        }
     }
 
     return shaderAsset;
@@ -63,4 +110,15 @@ core::ShaderAssetFormat::Resource core::ShaderAssetFormat::Resource::Buffer(uint
     return sa::Resource{.buffer = buffer};
 }
 
+core::ShaderAssetFormat::Shape core::ShaderAssetFormat::Shape::Vector(uint8_t count) {
+    return ShaderAssetFormat::Shape{
+        .vector = ShaderAssetFormat::Vector{count},
+    };
+}
+core::ShaderAssetFormat::Shape core::ShaderAssetFormat::Shape::Matrix(uint8_t rows,
+                                                                      uint8_t columns) {
+    return ShaderAssetFormat::Shape{
+        .matrix = ShaderAssetFormat::Matrix{rows, columns},
+    };
+}
 }  // namespace core

--- a/common/ShaderAssetFormat.cpp
+++ b/common/ShaderAssetFormat.cpp
@@ -1,6 +1,32 @@
 #include "ShaderAssetFormat.h"
+#include <cctype>
+#include <algorithm>
 
 namespace core {
+
+Semantic NameToSemantic(const std::string& semanticName, uint32_t index) {
+    std::string name = semanticName;
+    std::transform(name.begin(), name.end(), name.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
+
+    if (name == "POSITION") {
+        return Semantic::Position;
+    } else if (name == "NORMAL") {
+        return Semantic::Normal;
+    } else if (name == "TANGENT") {
+        return Semantic::Tangent;
+    } else if (name == "TEXCOORD") {
+        if (index < 8) {
+            return static_cast<Semantic>(static_cast<int>(Semantic::TexCoord0) + index);
+        }
+    } else if (name == "COLOR") {
+        if (index < 4) {
+            return static_cast<Semantic>(static_cast<int>(Semantic::Color0) + index);
+        }
+    }
+
+    return Semantic::Undefind;
+}
 
 std::expected<ShaderAssetFormat, Error> core::ShaderAssetFormat::LoadFromMemory(
     std::span<const uint8_t> memory) {

--- a/common/ShaderAssetFormat.cpp
+++ b/common/ShaderAssetFormat.cpp
@@ -25,7 +25,7 @@ Semantic NameToSemantic(const std::string& semanticName, uint32_t index) {
         }
     }
 
-    return Semantic::Undefind;
+    return Semantic::Undefined;
 }
 
 std::expected<ShaderAssetFormat, Error> core::ShaderAssetFormat::LoadFromMemory(

--- a/common/ShaderAssetFormat.h
+++ b/common/ShaderAssetFormat.h
@@ -10,7 +10,15 @@
 namespace core {
 struct ShaderAssetFormat {
     static constexpr uint32_t SHADER_ASSET_MAGIC = 0x52444853;
-    static constexpr uint32_t SHADER_ASSET_VERSION = 3;
+    static constexpr uint32_t SHADER_ASSET_VERSION = 4;
+
+    enum class Kind : uint8_t {
+        None,
+        Scalar,
+        Vector,
+        Matrix,
+        Struct,
+    };
 
     enum class SamplerType : uint8_t {
         BindingNotUsed,
@@ -50,14 +58,24 @@ struct ShaderAssetFormat {
         Unknown = 0xFF,
     };
 
+    enum class ScalarType : uint8_t {
+        F32,
+        F16,
+        U32,
+        I32,
+        Bool,
+        Undefined,
+    };
+
     inline void PrintTo(ResourceType type, std::ostream* os) { *os << magic_enum::enum_name(type); }
 
     enum class ShaderVisibility : uint8_t {
         None = 0x0,
         Vertex = 0x1,
         Fragment = 0x2,
+        Render = 0x03,  // Vertex | Fragment
         Compute = 0x4,
-        All = Vertex | Fragment | Compute
+        All = 0x07,  // Vertex | Fragment | Compute
     };
 
     struct Sampler {
@@ -74,10 +92,12 @@ struct ShaderAssetFormat {
         uint32_t bufferSize;
     };
 
-    union Resource {
-        Sampler sampler;
-        Texture texture;
-        Buffer buffer;
+    struct Resource {
+        union {
+            Sampler sampler;
+            Texture texture;
+            Buffer buffer;
+        };
 
         static Resource Buffer(uint32_t size);
     };
@@ -85,38 +105,55 @@ struct ShaderAssetFormat {
     struct alignas(64) Header {
         uint32_t magicNumber = SHADER_ASSET_MAGIC;
         uint16_t version = SHADER_ASSET_VERSION;
+        uint16_t vertexInputCount;
+        uint16_t vertexOutputCount;
+        uint16_t fragmentOutputCount;
         uint16_t bindingCount;
         uint32_t shaderSize;
         uint32_t threadGroupSize[3];
         ShaderVisibility entryShaderStage;
+        char _padding[33];
     };
 
     /**
      * @brief Flattened Resource's binding information
      *
      */
-    struct alignas(64) Binding {
+    struct alignas(32) Binding {
         uint32_t set;
         uint32_t binding;
         uint32_t id;
+        uint32_t nameIdx;
+        Resource resource = {.buffer = {0}};
         ResourceType resourceType;
         ShaderVisibility visibility;
-        Resource resource = {.buffer = {0}};
-        char name[32];
+        char _padding[10];
+    };
+
+    struct Variable {
+        Kind kind;
+        ScalarType scalarType;
+        uint8_t rows;
+        uint8_t columns;
+        uint32_t nameIdx;
+    };
+
+    struct ShaderParameter {
+        Variable variable;
+        uint32_t location;
+        uint32_t semanticNameIdx;
     };
 
     Header header;
+    std::vector<ShaderParameter> vertexInputs;
+    std::vector<ShaderParameter> vertexOutputs;
+    std::vector<ShaderParameter> fragmentOutputs;
     std::vector<Binding> bindings;
     std::vector<uint8_t> code;
+    std::vector<std::string> nameTable;
 
     static std::expected<ShaderAssetFormat, Error> LoadFromMemory(std::span<const uint8_t> memory);
 };
-
-inline ShaderAssetFormat::ShaderVisibility operator|(ShaderAssetFormat::ShaderVisibility a,
-                                                     ShaderAssetFormat::ShaderVisibility b) {
-    return static_cast<ShaderAssetFormat::ShaderVisibility>(static_cast<uint8_t>(a) |
-                                                            static_cast<uint8_t>(b));
-}
 
 }  // namespace core
 
@@ -128,11 +165,17 @@ struct std::formatter<core::ShaderAssetFormat::ResourceType> : std::formatter<st
     }
 };
 
-inline std::ostream& operator<<(std::ostream& os, core::ShaderAssetFormat::ResourceType type) {
-    return os << std::format("{}", type);
+
+inline core::ShaderAssetFormat::ShaderVisibility operator|(
+    core::ShaderAssetFormat::ShaderVisibility a,
+    core::ShaderAssetFormat::ShaderVisibility b) {
+    return static_cast<core::ShaderAssetFormat::ShaderVisibility>(static_cast<uint8_t>(a) |
+                                                                  static_cast<uint8_t>(b));
 }
 
-inline uint8_t operator&(core::ShaderAssetFormat::ShaderVisibility a,
-                         core::ShaderAssetFormat::ShaderVisibility b) {
-    return (static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
+inline core::ShaderAssetFormat::ShaderVisibility operator&(
+    core::ShaderAssetFormat::ShaderVisibility a,
+    core::ShaderAssetFormat::ShaderVisibility b) {
+    return static_cast<core::ShaderAssetFormat::ShaderVisibility>(static_cast<uint8_t>(a) &
+                                                                  static_cast<uint8_t>(b));
 }

--- a/common/ShaderAssetFormat.h
+++ b/common/ShaderAssetFormat.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <compare>
 #include <expected>
 #include <format>
 #include <iostream>
@@ -11,6 +12,12 @@ namespace core {
 struct ShaderAssetFormat {
     static constexpr uint32_t SHADER_ASSET_MAGIC = 0x52444853;
     static constexpr uint32_t SHADER_ASSET_VERSION = 4;
+
+    static constexpr uint32_t kInvalidIdx = -1;
+
+    enum class Flag : uint16_t {  // Reserved
+        None,
+    };
 
     enum class Kind : uint8_t {
         None,
@@ -100,20 +107,37 @@ struct ShaderAssetFormat {
         };
 
         static Resource Buffer(uint32_t size);
+
+        bool operator==(const Resource& rhs) const {
+            return std::memcmp(this, &rhs, sizeof(Resource)) == 0;
+        }
+        std::strong_ordering operator<=>(const Resource& rhs) const {
+            int res = std::memcmp(this, &rhs, sizeof(Resource));
+            return res <=> 0;
+        }
     };
 
     struct alignas(64) Header {
         uint32_t magicNumber = SHADER_ASSET_MAGIC;
         uint16_t version = SHADER_ASSET_VERSION;
-        uint16_t vertexInputCount;
-        uint16_t vertexOutputCount;
-        uint16_t fragmentOutputCount;
+        uint16_t parameterCount;
         uint16_t bindingCount;
+        uint16_t entryPointCount;
+        uint16_t variableCount;  // reserved
+        uint16_t indexCount;
+        uint32_t nameTableSize;
         uint32_t shaderSize;
-        uint32_t threadGroupSize[3];
-        ShaderVisibility entryShaderStage;
-        char _padding[33];
+        uint32_t parameterOffset;
+        uint32_t bindingOffset;
+        uint32_t entryPointOffset;
+        uint32_t variableOffset;
+        uint32_t indexOffset;
+        uint32_t nameTableOffset;
+        uint32_t shaderOffset;
+        char _padding[12] = {0};
     };
+
+    static_assert(sizeof(Header) == 64);
 
     /**
      * @brief Flattened Resource's binding information
@@ -123,34 +147,92 @@ struct ShaderAssetFormat {
         uint32_t set;
         uint32_t binding;
         uint32_t id;
-        uint32_t nameIdx;
+        uint32_t nameIdx = kInvalidIdx;
         Resource resource = {.buffer = {0}};
         ResourceType resourceType;
         ShaderVisibility visibility;
-        char _padding[10];
+        char _padding[10] = {0};
+
+        std::strong_ordering operator<=>(const Binding&) const = default;
+    };
+
+    struct Scalar {};
+    struct Vector {
+        uint8_t length;
+    };
+    struct Matrix {
+        uint8_t rows;
+        uint8_t columns;
+    };
+
+    struct Shape {
+        union {
+            Scalar scalar;
+            Vector vector;
+            Matrix matrix;
+        };
+
+        static Shape Scalar() { return Shape{.scalar = {}}; }
+        static Shape Vector(uint8_t count);
+        static Shape Matrix(uint8_t rows, uint8_t columns);
     };
 
     struct Variable {
         Kind kind;
         ScalarType scalarType;
-        uint8_t rows;
-        uint8_t columns;
-        uint32_t nameIdx;
+        Shape shape;
+        uint32_t nameIdx = kInvalidIdx;
+
+        bool operator==(const Variable& rhs) const {
+            if (kind != rhs.kind || scalarType != rhs.scalarType || nameIdx != rhs.nameIdx) {
+                return false;
+            }
+
+            switch (kind) {
+                case Kind::Scalar:
+                    return true;
+                case Kind::Vector:
+                    return shape.vector.length == rhs.shape.vector.length;
+                case Kind::Matrix:
+                    return shape.matrix.rows == rhs.shape.matrix.rows &&
+                           shape.matrix.columns == rhs.shape.matrix.columns;
+                default:
+                    return true;
+            }
+        }
     };
 
     struct ShaderParameter {
         Variable variable;
         uint32_t location;
-        uint32_t semanticNameIdx;
+        uint32_t semanticNameIdx = kInvalidIdx;
+
+        std::strong_ordering operator<=>(const ShaderParameter&) const = default;
     };
 
+    struct EntryPoint {
+        ShaderVisibility stage;
+        uint32_t nameIdx;
+
+        uint32_t ioStartIndex;
+        uint32_t bindingStartIndex;
+
+        uint16_t ioCount;
+        uint16_t bindingCount;
+
+        uint32_t _padding;
+    };
+    static_assert(sizeof(EntryPoint) == 24, "EntryPoint size must be 24 bytes!");
+
     Header header;
-    std::vector<ShaderParameter> vertexInputs;
-    std::vector<ShaderParameter> vertexOutputs;
-    std::vector<ShaderParameter> fragmentOutputs;
+    std::vector<ShaderParameter> parameters;
     std::vector<Binding> bindings;
+    std::vector<Variable> variables;  // reserved
+    std::vector<EntryPoint> entryPoints;
     std::vector<uint8_t> code;
-    std::vector<std::string> nameTable;
+    std::string nameTableData;
+    std::vector<std::string_view> tokens;
+    std::vector<uint32_t> indices;
 
     static std::expected<ShaderAssetFormat, Error> LoadFromMemory(std::span<const uint8_t> memory);
 };
@@ -164,7 +246,6 @@ struct std::formatter<core::ShaderAssetFormat::ResourceType> : std::formatter<st
         return std::formatter<std::string_view>::format(name, ctx);
     }
 };
-
 
 inline core::ShaderAssetFormat::ShaderVisibility operator|(
     core::ShaderAssetFormat::ShaderVisibility a,

--- a/common/ShaderAssetFormat.h
+++ b/common/ShaderAssetFormat.h
@@ -120,13 +120,13 @@ struct ShaderAssetFormat {
     struct alignas(64) Header {
         uint32_t magicNumber = SHADER_ASSET_MAGIC;
         uint16_t version = SHADER_ASSET_VERSION;
-        uint16_t parameterCount;
-        uint16_t bindingCount;
-        uint16_t entryPointCount;
-        uint16_t variableCount;  // reserved
-        uint16_t indexCount;
-        uint32_t nameTableSize;
-        uint32_t shaderSize;
+        uint16_t parameterCount = 0;
+        uint16_t bindingCount = 0;
+        uint16_t entryPointCount = 0;
+        uint16_t variableCount = 0;  // reserved
+        uint16_t indexCount = 0;
+        uint32_t nameTableSize = 0;
+        uint32_t shaderSize = 0;
         uint32_t parameterOffset;
         uint32_t bindingOffset;
         uint32_t entryPointOffset;
@@ -205,7 +205,7 @@ struct ShaderAssetFormat {
     struct ShaderParameter {
         Variable variable;
         uint32_t location;
-        uint32_t semanticNameIdx = kInvalidIdx;
+        Semantic semantic;
 
         std::strong_ordering operator<=>(const ShaderParameter&) const = default;
     };

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -92,47 +92,26 @@ target_include_directories(core PRIVATE ${TINYGLTF_INCLUDE_DIRS})
 # IDE(Visual Studio)에서 필터 정리
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${SOURCES})
 
-set(PBR_VS_SHDR "${CMAKE_CURRENT_BINARY_DIR}/asset/StandardPBR_VS.shdr")
-set(PBR_FS_SHDR "${CMAKE_CURRENT_BINARY_DIR}/asset/StandardPBR_FS.shdr")
-set(PBR_VS_HEADER "${CMAKE_CURRENT_BINARY_DIR}/asset/StandardPBR_VS.h")
-set(PBR_FS_HEADER "${CMAKE_CURRENT_BINARY_DIR}/asset/StandardPBR_FS.h")
+set(PBR_SHDR "${CMAKE_CURRENT_BINARY_DIR}/asset/StandardPBR.shdr")
+set(PBR_HEADER "${CMAKE_CURRENT_BINARY_DIR}/asset/StandardPBR.h")
 
 add_shader_asset(
     TARGET core
     INPUT "${CMAKE_CURRENT_SOURCE_DIR}/asset/StandardPBR.slang" 
-    ENTRY "vertexMain"
-    OUTPUT ${PBR_VS_SHDR}
-    INCLUDES "${CORE_INTEROP_HEADER_DIR}"
-)
-
-add_shader_asset(
-    TARGET core
-    INPUT "${CMAKE_CURRENT_SOURCE_DIR}/asset/StandardPBR.slang" 
-    ENTRY "fragmentMain"
-    OUTPUT ${PBR_FS_SHDR}
+    OUTPUT ${PBR_SHDR}
     INCLUDES "${CORE_INTEROP_HEADER_DIR}"
 )
 
 add_custom_command(
-    OUTPUT ${PBR_VS_HEADER}
+    OUTPUT ${PBR_HEADER}
     COMMAND python3 ${CMAKE_SOURCE_DIR}/tools/bin2header.py 
-        -i ${PBR_VS_SHDR} 
-        -o ${PBR_VS_HEADER} 
-        -n kStandardPBR_VS_Data 
-    DEPENDS ${PBR_VS_SHDR} 
-    COMMENT "Embedding StandardPBR VS into C++ header..."
+        -i ${PBR_SHDR} 
+        -o ${PBR_HEADER} 
+        -n kStandardPBR_Data 
+    DEPENDS ${PBR_SHDR} 
+    COMMENT "Embedding StandardPBR into C++ header..."
 )
 
-add_custom_command(
-    OUTPUT ${PBR_FS_HEADER}
-    COMMAND python3 ${CMAKE_SOURCE_DIR}/tools/bin2header.py 
-        -i ${PBR_FS_SHDR} 
-        -o ${PBR_FS_HEADER} 
-        -n kStandardPBR_FS_Data 
-    DEPENDS ${PBR_FS_SHDR} 
-    COMMENT "Embedding StandardPBR FS into C++ header..."
-)
-
-target_sources(core PRIVATE ${PBR_VS_HEADER} ${PBR_FS_HEADER})
+target_sources(core PRIVATE ${PBR_HEADER})
 
 target_include_directories(core PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -45,7 +45,7 @@
     "render/TextureManager.h" "render/TextureManager.cpp"
  "render/MeshManager.h"  "render/MeshManager.cpp"
  "render/Model.h"
-)
+ "render/VertexLayoutManager.h" "render/VertexLayoutManager.cpp" "wgx/types.h")
 
 include (../cmake/ShaderCompiler.cmake)
 

--- a/core/asset/StandardPBR.slang
+++ b/core/asset/StandardPBR.slang
@@ -20,7 +20,7 @@ struct AssembledVertex {
     [[vk::location(ShaderLoc::Normal)]]
     float3 normal : NORMAL;
     [[vk::location(ShaderLoc::UV)]]
-    float2 texcoord : TEXCOORD_0;
+    float2 texcoord : TEXCOORD0;
     [[vk::location(ShaderLoc::Tangent)]]
     float4 tangent : TANGENT;
 };

--- a/core/asset/StandardPBR.slang
+++ b/core/asset/StandardPBR.slang
@@ -35,6 +35,35 @@ struct Fragment {
     float4 color;
 };
 
+struct ColorVertex {
+    float3 position : POSITION;
+    float4 color : COLOR0;
+};
+
+struct ColorVertexStageOutput {
+    float4 sv_position : SV_Position;
+    float4 color : COLOR; 
+};
+
+[shader("vertex")]
+ColorVertexStageOutput vertexMain_Color(ColorVertex colorVertex) {
+    ColorVertexStageOutput output;
+
+    float3 position = colorVertex.position;
+
+    output.sv_position = mul(globalUniforms.viewProj, float4(position, 1.0f));
+    output.color = colorVertex.color;
+
+    return output;
+}
+
+[shader("fragment")]
+Fragment fragmentMain_Color(float4 color: COLOR) : SV_Target {
+    Fragment output;
+    output.color = color;
+    return output;
+}
+
 // Vertex  Shader
 struct VertexStageOutput {
     CoarseVertex coarseVertex : CoarseVertex;

--- a/core/import/GLTFImporter.cpp
+++ b/core/import/GLTFImporter.cpp
@@ -287,13 +287,13 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
             vertexData.resize(vertexData.size() + colorRange.size);
             std::byte* colorDst = vertexData.data() + colorRange.offset;
 
-            if (colorSpan.stride() == sizeof(glm::vec3)) {
+            if (colorSpan.stride() == sizeof(glm::vec4)) {
                 std::memcpy(colorDst, colorSpan.GetRawBytePtr(), colorRange.size);
             } else {
                 for (size_t i = 0; i < vertexCount; ++i) {
                     std::memcpy(colorDst + (i * colorSlot.stride),
                                 colorSpan.GetRawBytePtr() + (i * colorSpan.stride()),
-                                sizeof(glm::vec3));
+                                sizeof(glm::vec4));
                 }
             }
             currentRanges.push_back(colorRange);

--- a/core/import/GLTFImporter.cpp
+++ b/core/import/GLTFImporter.cpp
@@ -8,12 +8,15 @@
 
 #include "GLTFImporter.h"
 
+using core::memory::StridedSpan;
+
 namespace core::importer {
 
 const std::string kGltfPosition = "POSITION";
 const std::string kGltfTexCoord0 = "TEXCOORD_0";
 const std::string kGltfNormal = "NORMAL";
 const std::string kGltfTangent = "TANGENT";
+const std::string kGltfColor = "COLOR_0";
 
 AssetPath GLTFImporter::ToTextureID(int gltfTextureIndex) {
     return AssetPath{std::format("virtual://tex/{}", gltfTextureIndex)};
@@ -53,8 +56,8 @@ std::expected<MaterialAssetFormat, Error> GLTFImporter::ImportMaterial(
                            gltfMaterial.pbrMetallicRoughness.baseColorFactor[2],
                            gltfMaterial.pbrMetallicRoughness.baseColorFactor[3]));
     assetFormat.SetUniform("emissiveFactor", glm::vec<3, float>(gltfMaterial.emissiveFactor[0],
-                                                                  gltfMaterial.emissiveFactor[1],
-                                                                  gltfMaterial.emissiveFactor[2]));
+                                                                gltfMaterial.emissiveFactor[1],
+                                                                gltfMaterial.emissiveFactor[2]));
     assetFormat.SetUniform("normalScale", static_cast<float>(gltfMaterial.normalTexture.scale));
 
     assetFormat.SetUniform("metallicFactor",
@@ -142,7 +145,7 @@ std::expected<GLTFImportResult, Error> GLTFImporter::ImportFromFile(const std::s
                 modelNode.materialIds.push_back(ToMaterialID(primitive.material));
             } else {
                 modelNode.materialIds.push_back(AssetPath{"virtual://material/default"});
-        }
+            }
         }
 
         result.modelAsset.nodes.push_back(modelNode);
@@ -167,44 +170,134 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
         }
     }
 
-    std::vector<Vertex> vertexData;
-    vertexData.reserve(totalVertexCount);
+    std::vector<MeshAssetFormat::BufferRange> currentRanges;
+    std::vector<MeshAssetFormat::MeshVertexState> vertexStates;
+    std::vector<std::byte> vertexData;
+    vertexData.reserve(totalVertexCount * (12 + 36));
     std::vector<uint32_t> indexData;
     indexData.reserve(totalIndexCount);
     for (const tinygltf::Primitive& primitive : mesh.primitives) {
         MeshAssetFormat::SubMeshInfo subMeshInfo;
-        if (primitive.attributes.find(kGltfTexCoord0) == primitive.attributes.end()) {
-            continue;
-        }
-
         if (primitive.indices < 0) {
             continue;
         }
-        const auto posResult = GetAttributePtr<const glm::vec3>(gltfModel, primitive, kGltfPosition);
-        const auto texResult =
-            GetAttributePtr<const glm::vec2>(gltfModel, primitive, kGltfTexCoord0);
-        const auto norResult = GetAttributePtr<const glm::vec3>(gltfModel, primitive, kGltfNormal);
-        const auto tanResult = GetAttributePtr<const glm::vec4>(gltfModel, primitive, kGltfTangent);
-        if (!posResult.has_value() || !texResult.has_value()) {
+        auto posSpanOpt = GetAttributePtr<const glm::vec3>(gltfModel, primitive, kGltfPosition);
+        if (!posSpanOpt) {
             continue;
         }
-        const auto posSpan = posResult.value();
-        const auto texSpan = texResult.value();
-        const auto norSpan = norResult.has_value()
-                           ? norResult.value()
-                           : core::memory::StridedSpan<const glm::vec3>::MakeZero(posSpan.size());
-        auto tanSpan = tanResult.has_value()
-                           ? tanResult.value()
-                           : core::memory::StridedSpan<const glm::vec4>::MakeZero(posSpan.size());
 
-        subMeshInfo.baseVertexLocation = vertexData.size();
-        subMeshInfo.vertexType = VertexType::StandardMesh;
+        MeshAssetFormat::MeshVertexState currentState;
+        subMeshInfo.bufferRangeStart = currentRanges.size();
+        auto posSpan = posSpanOpt.value();
+        size_t vertexCount = posSpan.size();
 
-        for (size_t i = 0; i < posSpan.size(); ++i) {
-            vertexData.push_back(Vertex{.position = posSpan[i],
-                                        .normal = norSpan[i],
-                                        .uv = texSpan[i],
-                                        .tangent = tanSpan[i]});
+        MeshAssetFormat::MeshBufferSlot posSlot{
+            .stepMode = MeshAssetFormat::StepMode::Vertex,
+            .stride = sizeof(glm::vec3),
+            .attributeCount = 1,
+            .attributes = {MeshAssetFormat::MeshAttribute{MeshAssetFormat::VertexFormat::Float32x3,
+                                                          Semantic::Position, 0}}};
+        currentState.bufferSlots[currentState.slotCount++] = posSlot;
+
+        MeshAssetFormat::BufferRange posRange{
+            .offset = static_cast<uint32_t>(vertexData.size()),
+            .size = static_cast<uint32_t>(vertexCount * posSlot.stride)};
+        vertexData.resize(vertexData.size() + posRange.size);
+        std::byte* posDst = vertexData.data() + posRange.offset;
+
+        // Fast-path 최적화 (연속적일 경우 O(1) 복사)
+        if (posSpan.stride() == sizeof(glm::vec3)) {
+            std::memcpy(posDst, posSpan.GetRawBytePtr(), posRange.size);
+        } else {
+            for (size_t i = 0; i < vertexCount; ++i) {
+                std::memcpy(posDst + (i * posSlot.stride),
+                            posSpan.GetRawBytePtr() + (i * posSpan.stride()), sizeof(glm::vec3));
+            }
+        }
+        currentRanges.push_back(posRange);
+
+        auto texSpanOpt = GetAttributePtr<const glm::vec2>(gltfModel, primitive, kGltfTexCoord0);
+        if (texSpanOpt) {
+            auto texSpan = texSpanOpt.value();
+            auto norSpanOpt = GetAttributePtr<const glm::vec3>(gltfModel, primitive, kGltfNormal);
+            auto tanSpanOpt = GetAttributePtr<const glm::vec4>(gltfModel, primitive, kGltfTangent);
+
+            // 누락된 데이터는 MakeZero(임시 0버퍼)로 폴백 처리
+            auto norSpan = norSpanOpt.has_value()
+                               ? norSpanOpt.value()
+                               : core::memory::StridedSpan<const glm::vec3>::MakeZero(vertexCount);
+            auto tanSpan = tanSpanOpt.has_value()
+                               ? tanSpanOpt.value()
+                               : core::memory::StridedSpan<const glm::vec4>::MakeZero(vertexCount);
+
+            MeshAssetFormat::MeshBufferSlot surSlot{
+                .stepMode = MeshAssetFormat::StepMode::Vertex,
+                .stride = 12 + 8 + 16,  // Normal + UV + Tangent
+                .attributeCount = 3,
+                .attributes = {
+                    MeshAssetFormat::MeshAttribute{MeshAssetFormat::VertexFormat::Float32x3,
+                                                   Semantic::Normal, 0},
+                    MeshAssetFormat::MeshAttribute{MeshAssetFormat::VertexFormat::Float32x2,
+                                                   Semantic::TexCoord0, 12},
+                    MeshAssetFormat::MeshAttribute{MeshAssetFormat::VertexFormat::Float32x4,
+                                                   Semantic::Tangent, 20}}};
+            currentState.bufferSlots[currentState.slotCount++] = surSlot;
+
+            MeshAssetFormat::BufferRange surRange{
+                .offset = static_cast<uint32_t>(vertexData.size()),
+                .size = static_cast<uint32_t>(vertexCount * surSlot.stride)};
+            vertexData.resize(vertexData.size() + surRange.size);
+            std::byte* surDst = vertexData.data() + surRange.offset;
+
+            struct RawSpan {
+                const std::byte* data;
+                size_t stride;
+            };
+            std::array<RawSpan, 3> activeSpans = {
+                RawSpan{norSpan.GetRawBytePtr(), norSpan.stride()},
+                RawSpan{texSpan.GetRawBytePtr(), texSpan.stride()},
+                RawSpan{tanSpan.GetRawBytePtr(), tanSpan.stride()}};
+
+            for (size_t i = 0; i < vertexCount; ++i) {
+                std::byte* currentVertDst = surDst + (i * surSlot.stride);
+                for (size_t j = 0; j < surSlot.attributeCount; ++j) {
+                    size_t payloadSize =
+                        MeshAssetFormat::GetVertexFormatSize(surSlot.attributes[j].format);
+                    const std::byte* srcPtr = activeSpans[j].data + (i * activeSpans[j].stride);
+                    std::memcpy(currentVertDst, srcPtr, payloadSize);
+                    currentVertDst += payloadSize;
+                }
+            }
+            currentRanges.push_back(surRange);
+        }
+
+        auto colorSpanOpt = GetAttributePtr<const glm::vec4>(gltfModel, primitive, kGltfColor);
+        if (colorSpanOpt) {
+            auto colorSpan = colorSpanOpt.value();
+            MeshAssetFormat::MeshBufferSlot colorSlot{
+                .stepMode = MeshAssetFormat::StepMode::Vertex,
+                .stride = sizeof(glm::vec4),
+                .attributeCount = 1,
+                .attributes = {MeshAssetFormat::MeshAttribute{MeshAssetFormat::VertexFormat::Float32x4, Semantic::Color0, 0}},
+            };
+            currentState.bufferSlots[currentState.slotCount++] = colorSlot;
+
+            MeshAssetFormat::BufferRange colorRange{
+                .offset = static_cast<uint32_t>(vertexData.size()),
+                .size = static_cast<uint32_t>(vertexCount * colorSlot.stride)};
+            vertexData.resize(vertexData.size() + colorRange.size);
+            std::byte* colorDst = vertexData.data() + colorRange.offset;
+
+            if (colorSpan.stride() == sizeof(glm::vec3)) {
+                std::memcpy(colorDst, colorSpan.GetRawBytePtr(), colorRange.size);
+            } else {
+                for (size_t i = 0; i < vertexCount; ++i) {
+                    std::memcpy(colorDst + (i * colorSlot.stride),
+                                colorSpan.GetRawBytePtr() + (i * colorSpan.stride()),
+                                sizeof(glm::vec3));
+                }
+            }
+            currentRanges.push_back(colorRange);
         }
 
         const auto& indexAccessor = gltfModel.accessors[primitive.indices];
@@ -214,13 +307,13 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
         const void* indices = reinterpret_cast<const void*>(
             &indexBuffer.data[indexBufferView.byteOffset + indexAccessor.byteOffset]);
         subMeshInfo.indexCount = indexAccessor.count;
-        subMeshInfo.baseIndexLocation = indexData.size();
+        subMeshInfo.indexStart = indexData.size();
+
         if (indexAccessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT) {
             const uint32_t* intIndices = reinterpret_cast<const uint32_t*>(indices);
-            size_t indexSize = tinygltf::GetComponentSizeInBytes(indexAccessor.componentType) *
-                               indexAccessor.count;
-            std::span<const uint32_t> indexRnage(intIndices, indexSize);
-            indexData.append_range(indexRnage);
+
+            std::span<const uint32_t> indexRange(intIndices, indexAccessor.count);
+            indexData.append_range(indexRange);
 
         } else if (indexAccessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT) {
             const uint16_t* shortIndices = reinterpret_cast<const uint16_t*>(indices);
@@ -236,14 +329,28 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
             return std::unexpected(Error{ErrorType::AssetParsingError,
                                          "Unsupported index component type in glTF mesh!"});
         }
+
+        auto it = std::ranges::find(vertexStates, currentState);
+        uint32_t stateIndex = 0;
+        if (it != vertexStates.end()) {
+            stateIndex = static_cast<uint32_t>(std::distance(vertexStates.begin(), it));
+        } else {
+            stateIndex = static_cast<uint32_t>(vertexStates.size());
+            vertexStates.push_back(currentState);
+        }
+
+        subMeshInfo.stateIndex = stateIndex;
+        subMeshInfo.bufferRangeCount = currentRanges.size() - subMeshInfo.bufferRangeStart;
+
         subMeshInfos.push_back(subMeshInfo);
     }
 
-    std::byte* vertexPtr = reinterpret_cast<std::byte*>(vertexData.data());
     return MeshAssetFormat{
+        .states = std::move(vertexStates),
+        .bufferRanges = std::move(currentRanges),
         .subMeshes = std::move(subMeshInfos),
         .indexData = std::move(indexData),
-        .vertexData = std::vector(vertexPtr, vertexPtr + vertexData.size() * sizeof(Vertex)),
+        .vertexData = std::move(vertexData),  // std::move 사용
     };
 }
 

--- a/core/import/GLTFImporter.cpp
+++ b/core/import/GLTFImporter.cpp
@@ -205,7 +205,6 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
         vertexData.resize(vertexData.size() + posRange.size);
         std::byte* posDst = vertexData.data() + posRange.offset;
 
-        // Fast-path 최적화 (연속적일 경우 O(1) 복사)
         if (posSpan.stride() == sizeof(glm::vec3)) {
             std::memcpy(posDst, posSpan.GetRawBytePtr(), posRange.size);
         } else {
@@ -222,7 +221,6 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
             auto norSpanOpt = GetAttributePtr<const glm::vec3>(gltfModel, primitive, kGltfNormal);
             auto tanSpanOpt = GetAttributePtr<const glm::vec4>(gltfModel, primitive, kGltfTangent);
 
-            // 누락된 데이터는 MakeZero(임시 0버퍼)로 폴백 처리
             auto norSpan = norSpanOpt.has_value()
                                ? norSpanOpt.value()
                                : core::memory::StridedSpan<const glm::vec3>::MakeZero(vertexCount);
@@ -278,7 +276,8 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
                 .stepMode = MeshAssetFormat::StepMode::Vertex,
                 .stride = sizeof(glm::vec4),
                 .attributeCount = 1,
-                .attributes = {MeshAssetFormat::MeshAttribute{MeshAssetFormat::VertexFormat::Float32x4, Semantic::Color0, 0}},
+                .attributes = {MeshAssetFormat::MeshAttribute{
+                    MeshAssetFormat::VertexFormat::Float32x4, Semantic::Color0, 0}},
             };
             currentState.bufferSlots[currentState.slotCount++] = colorSlot;
 
@@ -350,7 +349,7 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
         .bufferRanges = std::move(currentRanges),
         .subMeshes = std::move(subMeshInfos),
         .indexData = std::move(indexData),
-        .vertexData = std::move(vertexData),  // std::move 사용
+        .vertexData = std::move(vertexData),
     };
 }
 

--- a/core/import/GLTFImporter.cpp
+++ b/core/import/GLTFImporter.cpp
@@ -221,6 +221,9 @@ std::expected<MeshAssetFormat, Error> GLTFImporter::ImportMesh(const tinygltf::M
             auto norSpanOpt = GetAttributePtr<const glm::vec3>(gltfModel, primitive, kGltfNormal);
             auto tanSpanOpt = GetAttributePtr<const glm::vec4>(gltfModel, primitive, kGltfTangent);
 
+            // TODO!(#7; sunghyun): Replace MakeZero padding with true dynamic packing. Currently,
+            // standard shaders strictly require Normal and Tangent inputs. This bandwidth waste
+            // will be resolved once the Shader Permutation system (#7) is implemented.
             auto norSpan = norSpanOpt.has_value()
                                ? norSpanOpt.value()
                                : core::memory::StridedSpan<const glm::vec3>::MakeZero(vertexCount);

--- a/core/import/Importer.h
+++ b/core/import/Importer.h
@@ -39,7 +39,7 @@ struct MeshResult {
 
 
 struct ShaderImportResult {
-    ShaderAssetFormat shaderBlob;
+    ShaderAssetFormat shaderAsset;
     AssetPath assetPath;
 };
 }  // namespace core::importer

--- a/core/import/Importer.h
+++ b/core/import/Importer.h
@@ -37,13 +37,9 @@ struct MeshResult {
     AssetPath assetPath;
 };
 
-struct ShaderBlob {
-    std::vector<uint8_t> shaderCode;
-    core::render::ShaderReflectionData reflection;
-};
 
 struct ShaderImportResult {
-    ShaderBlob shaderBlob;
+    ShaderAssetFormat shaderBlob;
     AssetPath assetPath;
 };
 }  // namespace core::importer

--- a/core/import/ShdrImporter.cpp
+++ b/core/import/ShdrImporter.cpp
@@ -7,13 +7,13 @@ namespace core::importer {
 
 std::expected<ShaderImportResult, Error> core::importer::ShdrImporter::ShdrImport(
     const std::string& shaderPath) {
-    const auto blobOrError =
+    const auto shaderAssetOrError =
         util::ReadFileToByte(shaderPath).and_then(ShaderAssetFormat::LoadFromMemory);
-    if (!blobOrError.has_value()) {
+    if (!shaderAssetOrError.has_value()) {
         return std::unexpected(Error::Parse(""));
     }
     return ShaderImportResult{
-        blobOrError.value(),
+        shaderAssetOrError.value(),
         AssetPath{shaderPath},
     };
 }

--- a/core/import/ShdrImporter.cpp
+++ b/core/import/ShdrImporter.cpp
@@ -7,9 +7,8 @@ namespace core::importer {
 
 std::expected<ShaderImportResult, Error> core::importer::ShdrImporter::ShdrImport(
     const std::string& shaderPath) {
-    const auto blobOrError = util::ReadFileToByte(shaderPath)
-                                 .and_then(ShaderAssetFormat::LoadFromMemory)
-                                 .and_then(ShdrImporter::ShdrConvert);
+    const auto blobOrError =
+        util::ReadFileToByte(shaderPath).and_then(ShaderAssetFormat::LoadFromMemory);
     if (!blobOrError.has_value()) {
         return std::unexpected(Error::Parse(""));
     }
@@ -19,46 +18,6 @@ std::expected<ShaderImportResult, Error> core::importer::ShdrImporter::ShdrImpor
     };
 }
 
-std::expected<ShaderBlob, Error> ShdrImporter::ShdrConvert(const core::ShaderAssetFormat& shdr) {
-    using Fmt = ShaderAssetFormat;
 
-    const std::vector<Fmt::Binding>& bindings = shdr.bindings;
-
-    render::ShaderReflectionData reflection;
-
-    reflection.entryShaderStage = shdr.header.entryShaderStage;
-
-    reflection.bindings.reserve(bindings.size());
-
-    auto& groups = reflection.groups;
-
-    for (size_t i = 0; i < bindings.size(); ++i) {
-        const Fmt::Binding& binding = bindings[i];
-
-        uint32_t size = 0;
-        if (binding.resourceType == Fmt::ResourceType::UniformBuffer) {
-            size = binding.resource.buffer.bufferSize;
-        }
-        render::BindingInfo bindingInfo{
-            .set = binding.set,
-            .binding = binding.binding,
-            .id = binding.id,
-            .resourceType = binding.resourceType,
-            .visibility = binding.visibility,
-            .resource = binding.resource,
-        };
-
-        reflection.bindings.push_back(bindingInfo);
-        if (groups[binding.set].count == 0) {
-            groups[binding.set].offset = reflection.bindings.size() - 1;
-        }
-        groups[binding.set].count++;
-    }
-
-    return ShaderBlob{
-        .shaderCode = std::move(shdr.code),
-        .reflection = std::move(reflection),
-    };
-}
 
 }  // namespace core::importer

--- a/core/import/ShdrImporter.h
+++ b/core/import/ShdrImporter.h
@@ -6,7 +6,7 @@
 #include "ShaderAssetFormat.h"
 #include "render/ShaderAsset.h"
 namespace core::render {
-class ShaderReflectionData;
+class ShaderReflection;
 }
 namespace core::importer {
 
@@ -15,6 +15,5 @@ namespace core::importer {
 class ShdrImporter {
   public:
     static std::expected<ShaderImportResult, Error> ShdrImport(const std::string& shaderPath);
-    static std::expected<ShaderBlob, Error> ShdrConvert(const core::ShaderAssetFormat& shdr);
 };
 }  // namespace core::importer

--- a/core/memory/StridedSpan.h
+++ b/core/memory/StridedSpan.h
@@ -121,6 +121,7 @@ class StridedSpan {
         return MakeRepeated(kZero, count);
     }
 
+
     // ¿Œµ¶Ω∫ ¡¢±Ÿ
     T& operator[](size_type index) const {
         assert(index < m_count);
@@ -139,14 +140,19 @@ class StridedSpan {
     uint32_t stride() const { return m_stride; }
     bool empty() const { return m_count == 0; }
 
+    const std::byte* GetRawBytePtr() const { return reinterpret_cast<const std::byte*>(m_data); }
+
     T& front() { return *begin(); }
     T& back() { return *(begin() + (m_count - 1)); }
+
+    static StridedSpan<const std::byte> ToByteSpan(const StridedSpan&& span) {
+        return StridedSpan<const std::byte>(span.m_data, span.m_stride, span.m_count);
+    }
 
   private:
     InternalPtr m_data;
     uint32_t m_stride;
     size_type m_count;
 };
-
 
 }  // namespace core::memory

--- a/core/render/Material.cpp
+++ b/core/render/Material.cpp
@@ -103,4 +103,21 @@ void Material::SetTexture(PropertyId id, AssetView<Texture> texture) {
     m_bindGroup = nullptr;
 }
 
+PipelineDesc Material::GetPipelineDesc(const MeshAssetFormat::MeshVertexState& vertexState) {
+    PipelineDesc desc;
+    desc.shaderAsset = m_shaderView;
+
+
+    if (vertexState.HasAttribute(Semantic::Color0)) {
+        desc.vertexEntry = "vertexMain_Color";
+        desc.fragmentEntry = "fragmentMain_Color";
+    } else {
+        desc.vertexEntry = "vertexMain";
+        desc.fragmentEntry = "fragmentMain";
+    }
+    desc.vertexState = vertexState;
+
+    return desc;
+}
+
 }  // namespace core::render

--- a/core/render/Material.cpp
+++ b/core/render/Material.cpp
@@ -35,7 +35,7 @@ void Material::RebuildBindGroup() {
     const auto& bindGroupLayout = m_shaderView->GetBindGroupLayout(kSetNumberMaterial);
     const auto& reflection = m_shaderView->GetReflection();
     const auto& entryInfos = reflection.GetGroup(kSetNumberMaterial);
-    const auto& uniformInfo = reflection.GetMaterialVariableInfos();
+    //const auto& uniformInfo = reflection.GetMaterialVariableInfos();
 
     std::vector<wgpu::BindGroupEntry> entries;
     for (uint32_t i = 0; i < entryInfos.size(); ++i) {

--- a/core/render/Material.h
+++ b/core/render/Material.h
@@ -2,6 +2,7 @@
 #include <concepts>
 #include <map>
 
+#include "PipelineManager.h"
 #include "LayoutCache.h"
 #include "ShaderAsset.h"
 #include "Texture.h"
@@ -50,6 +51,8 @@ class Material {
     AssetView<ShaderAsset> GetShader() const { return m_shaderView; }
 
     void UpdateUniform();
+
+    PipelineDesc GetPipelineDesc(const MeshAssetFormat::MeshVertexState& vertexState);
 
     wgpu::BindGroup GetBindGroup();
 

--- a/core/render/Material.h
+++ b/core/render/Material.h
@@ -3,7 +3,6 @@
 #include <map>
 
 #include "LayoutCache.h"
-#include "PipelineManager.h"
 #include "ShaderAsset.h"
 #include "Texture.h"
 #include "render.h"

--- a/core/render/MaterialManager.cpp
+++ b/core/render/MaterialManager.cpp
@@ -41,24 +41,21 @@ Handle MaterialManager::LoadMaterial(const importer::MaterialResult& materialRes
 }
 
 Material MaterialManager::CreateMaterialFromShader(AssetView<ShaderAsset> shaderAsset) {
-    if (!shaderAsset->IsValidRenderShader()) {
-        return Material();
-    }
 
-    const ShaderReflectionData& bindGroupInfos = shaderAsset->GetReflection();
+    const ShaderReflection& bindGroupInfos = shaderAsset->GetReflection();
 
-    const auto variables = bindGroupInfos.GetMaterialVariableInfos();
+    //const auto variables = bindGroupInfos.GetMaterialVariableInfos();
 
     size_t bufferSize = bindGroupInfos.materialUniformSize;
     Material material = [&]() {
         if (bufferSize) {
             std::unordered_map<PropertyId, Material::VariableInfo> variableInfo;
-            for (const auto& var : variables) {
-                variableInfo[var.id] = {
-                    .offset = var.offset,
-                    .size = var.size,
-                };
-            }
+            //for (const auto& var : variables) {
+            //    variableInfo[var.id] = {
+            //        .offset = var.offset,
+            //        .size = var.size,
+            //    };
+            //}
 
             wgpu::BufferDescriptor bufferDesc{
                 .usage = wgpu::BufferUsage::Uniform | wgpu::BufferUsage::CopyDst,

--- a/core/render/MaterialManager.cpp
+++ b/core/render/MaterialManager.cpp
@@ -12,7 +12,14 @@ MaterialManager::MaterialManager(Device* device,
       m_assetManager(assetManager),
       m_layoutCache(layoutCache),
       m_shaderManager(shaderManager),
-      m_textureManager(textureManager) {}
+      m_textureManager(textureManager) {
+    importer::MaterialResult defaultMaterialResult{
+        .materialAsset = MaterialAssetFormat{},
+        .assetPath = AssetPath{"virtual://material/default"},
+    };
+
+    LoadMaterial(defaultMaterialResult);
+}
 
 Handle MaterialManager::LoadMaterial(const importer::MaterialResult& materialResult) {
     if (auto it = m_materialCache.find(materialResult.assetPath); it != m_materialCache.end()) {

--- a/core/render/Mesh.cpp
+++ b/core/render/Mesh.cpp
@@ -2,40 +2,4 @@
 
 namespace core::render {
 
-wgpu::VertexBufferLayout core::render::Vertex::GetWgpuVertexLayout() {
-    static const std::array<wgpu::VertexAttribute, 4> attribute = {
-
-        wgpu::VertexAttribute{.format = wgpu::VertexFormat::Float32x3,
-                              .offset = offsetof(Vertex, position),
-                              .shaderLocation = ShaderLoc::Position},
-        wgpu::VertexAttribute{.format = wgpu::VertexFormat::Float32x3,
-                              .offset = offsetof(Vertex, normal),
-                              .shaderLocation = ShaderLoc::Normal},
-        wgpu::VertexAttribute{.format = wgpu::VertexFormat::Float32x2,
-                              .offset = offsetof(Vertex, uv),
-                              .shaderLocation = ShaderLoc::UV},
-        wgpu::VertexAttribute{.format = wgpu::VertexFormat::Float32x4,
-                              .offset = offsetof(Vertex, tangent),
-                              .shaderLocation = ShaderLoc::Tangent},
-    };
-
-    return wgpu::VertexBufferLayout{
-        .stepMode = wgpu::VertexStepMode::Vertex,
-        .arrayStride = sizeof(Vertex),
-        .attributeCount = attribute.size(),
-        .attributes = attribute.data(),
-    };
-}
-
-wgpu::VertexBufferLayout core::render::MapVertexDesc(VertexType type) {
-    switch (type) {
-        case VertexType::StandardMesh:
-            return Vertex::GetWgpuVertexLayout();
-        case VertexType::None:
-            return {};
-        default:
-            return {};
-    }
-}
-
 }  // namespace core::render

--- a/core/render/Mesh.h
+++ b/core/render/Mesh.h
@@ -2,36 +2,36 @@
 
 #include <array>
 
+#include <MeshAssetFormat.h>
+
+#include "VertexLayoutManager.h"
 #include "render.h"
 
 namespace core::render {
 
-struct Vertex {
-    glm::vec3 position;
-    glm::vec3 normal;
-    glm::vec2 uv;
-    glm::vec4 tangent;
-
-    static wgpu::VertexBufferLayout GetWgpuVertexLayout();
-};
-
-enum class VertexType {
-    None = 0,
-    StandardMesh = 1,
-};
-
-wgpu::VertexBufferLayout MapVertexDesc(VertexType type);
-
-struct SubMeshInfo {
-    uint32_t indexCount;
-    uint32_t indexOffset;
-    uint32_t vertexOffset;
-};
-
 struct Mesh {
     wgpu::Buffer vertexBuffer;
     wgpu::Buffer indexBuffer;
-    std::vector<SubMeshInfo> submeshInfos;
+    std::unique_ptr< MeshAssetFormat> meshAssetFormat;
+
+    std::span<const MeshAssetFormat::SubMeshInfo> GetSubMeshInfors() const {
+        return std::span<const MeshAssetFormat::SubMeshInfo>(meshAssetFormat->subMeshes.data(),
+                                                       meshAssetFormat->subMeshes.size());
+    }
+
+    const MeshAssetFormat::SubMeshInfo& GetSubMeshInfors(uint32_t index) const {
+        return meshAssetFormat->subMeshes[index];
+    }
+
+    const MeshAssetFormat::MeshVertexState& GetVertexState(uint32_t index) const {
+        return meshAssetFormat->states[index];
+    }
+
+    std::span<const MeshAssetFormat::BufferRange> GetBufferRanges(uint32_t start, uint32_t count) const {
+        return std::span<const MeshAssetFormat::BufferRange>(
+            meshAssetFormat->bufferRanges.data() + start, count);
+    }
+
 };
 
 }  // namespace core::render

--- a/core/render/Mesh.h
+++ b/core/render/Mesh.h
@@ -19,7 +19,7 @@ struct Mesh {
                                                        meshAssetFormat->subMeshes.size());
     }
 
-    const MeshAssetFormat::SubMeshInfo& GetSubMeshInfors(uint32_t index) const {
+    const MeshAssetFormat::SubMeshInfo& GetSubMeshInfos(uint32_t index) const {
         return meshAssetFormat->subMeshes[index];
     }
 

--- a/core/render/MeshManager.cpp
+++ b/core/render/MeshManager.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "MeshManager.h"
 
 core::Handle core::render::MeshManager::LoadMesh(const importer::MeshResult& meshResult) {
@@ -14,20 +16,11 @@ core::Handle core::render::MeshManager::LoadMesh(const importer::MeshResult& mes
         meshAssetFormat.indexData.data(), meshAssetFormat.indexData.size() * sizeof(uint32_t),
         wgpu::BufferUsage::Index | wgpu::BufferUsage::CopyDst);
 
-    std::vector<SubMeshInfo> subMeshInfos;
-    subMeshInfos.reserve(meshAssetFormat.subMeshes.size());
-    for (const auto& subMeshAsset : meshAssetFormat.subMeshes) {
-        SubMeshInfo subMeshInfo;
-        subMeshInfo.indexCount = subMeshAsset.indexCount;
-        subMeshInfo.indexOffset = subMeshAsset.baseIndexLocation;
-        subMeshInfo.vertexOffset = subMeshAsset.baseVertexLocation;
-        subMeshInfos.push_back(subMeshInfo);
-    }
 
     Mesh mesh{
         .vertexBuffer = vertexBuffer,
         .indexBuffer = indexBuffer,
-        .submeshInfos = std::move(subMeshInfos),
+        .meshAssetFormat = std::make_unique<MeshAssetFormat>( meshResult.meshAsset),
     };
     Handle handle = m_assetManager->StoreMesh(std::move(mesh));
     m_meshCache[meshResult.assetPath] = handle;

--- a/core/render/MeshManager.h
+++ b/core/render/MeshManager.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "import/Importer.h"
+#include "VertexLayoutManager.h"
 #include "AssetManager.h"
 #include "MeshAssetFormat.h"
 #include "render.h"

--- a/core/render/PipelineManager.cpp
+++ b/core/render/PipelineManager.cpp
@@ -16,6 +16,9 @@ static constexpr wgpu::VertexFormat MapFormat(MeshAssetFormat::VertexFormat form
             return wgpu::VertexFormat::Float32x3;
         case MeshAssetFormat::VertexFormat::Float32x4:
             return wgpu::VertexFormat::Float32x4;
+        default:
+            assert(false && "Unhandled VertexFormat provided");
+            std::unreachable();
     }
 }
 

--- a/core/render/PipelineManager.cpp
+++ b/core/render/PipelineManager.cpp
@@ -1,9 +1,35 @@
+#include <ranges>
 
-#include "PipelineManager.h"
 #include "Mesh.h"
+#include "PipelineManager.h"
 #include "render/util.h"
 
 namespace core::render {
+
+static constexpr wgpu::VertexFormat MapFormat(MeshAssetFormat::VertexFormat format) {
+    switch (format) {
+        case MeshAssetFormat::VertexFormat::Float32:
+            return wgpu::VertexFormat::Float32;
+        case MeshAssetFormat::VertexFormat::Float32x2:
+            return wgpu::VertexFormat::Float32x2;
+        case MeshAssetFormat::VertexFormat::Float32x3:
+            return wgpu::VertexFormat::Float32x3;
+        case MeshAssetFormat::VertexFormat::Float32x4:
+            return wgpu::VertexFormat::Float32x4;
+    }
+}
+
+static constexpr wgpu::VertexStepMode MapStepMode(MeshAssetFormat::StepMode stepMode) {
+    switch (stepMode) {
+        case MeshAssetFormat::StepMode::Vertex:
+            return wgpu::VertexStepMode::Vertex;
+        case MeshAssetFormat::StepMode::Instance:
+            return wgpu::VertexStepMode::Instance;
+        default:
+            return wgpu::VertexStepMode::Undefined;
+    }
+}
+
 PipelineManager::PipelineManager(Device* device,
                                  LayoutCache* layoutCache,
                                  wgpu::BindGroupLayoutDescriptor& globalBindGroupLayoutDesc)
@@ -11,7 +37,7 @@ PipelineManager::PipelineManager(Device* device,
     m_globalBindGroupLayout = m_layoutCache->GetBindGroupLayout(globalBindGroupLayoutDesc);
 }
 
- wgpu::RenderPipeline PipelineManager::GetRenderPipeline(const PipelineDesc& desc) {
+wgpu::RenderPipeline PipelineManager::GetRenderPipeline(const PipelineDesc& desc) {
     if (m_pipelineCache.contains(desc)) {
         return m_pipelineCache.at(desc);
     }
@@ -29,26 +55,54 @@ PipelineManager::PipelineManager(Device* device,
 
     const auto& renderPipelineLayout = m_layoutCache->GetPipelineLayout(pipelineLayoutDesc);
 
-    wgpu::VertexBufferLayout bufferLayout = MapVertexDesc(desc.vertexType);
-    std::array<wgpu::VertexBufferLayout, 1> vertexBufferLayouts{
-        bufferLayout,
-    };
+    std::span<const ShaderReflection::Parameter> inputs =
+        desc.shaderAsset->GetReflection().GetEntryInput(desc.vertexEntry);
+
+    std::vector<wgpu::VertexBufferLayout> vertexLayouts;
+
+    for (const auto& slot : desc.vertexState.bufferSlots) {
+        std::vector<wgx::VertexAttribute> activeAttributes;
+
+        for (uint32_t i = 0; i < slot.attributeCount; ++i) {
+            auto& meshAtt = slot.attributes[i];
+            auto it = std::ranges::find_if(inputs, [&](const ShaderReflection::Parameter& param) {
+                return param.semantic == meshAtt.semantic;
+            });
+
+            if (it != inputs.end()) {
+                activeAttributes.push_back(wgx::VertexAttribute{.format = MapFormat(meshAtt.format),
+                                                                .offset = meshAtt.offset,
+                                                                .shaderLocation = it->location});
+            }
+        }
+
+        if (activeAttributes.empty()) {
+            continue;
+        }
+
+        Handle layoutHandle = m_vertexLayoutManager.GetVertexLayout(
+            wgx::VertexBufferLayout{.stepMode = MapStepMode(slot.stepMode),
+                                    .arrayStride = slot.stride,
+                                    .attributes = std::move(activeAttributes)});
+
+        vertexLayouts.push_back(m_vertexLayoutManager.GetVertexLayout(layoutHandle)->GetLayout());
+    }
 
     wgpu::ColorTargetState targets{.format = m_device->GetSurfaceConfig().format,
                                    .blend = &desc.blendState,
                                    .writeMask = wgpu::ColorWriteMask::All};
     wgpu::FragmentState fragment =
-        wgpu::FragmentState{.module = desc.shaderAsset->GetFragmentModule(),
-                            .entryPoint = "fragmentMain",
+        wgpu::FragmentState{.module = desc.shaderAsset->GetShaderModule(),
+                            .entryPoint = desc.fragmentEntry.c_str(),
                             .targetCount = 1,
                             .targets = &targets};
     wgpu::RenderPipeline renderPipeline =
         m_device->CreateRenderPipeline(wgpu::RenderPipelineDescriptor{
             .layout = renderPipelineLayout,
-            .vertex = wgpu::VertexState{.module = desc.shaderAsset->GetVertexModule(),
-                                        .entryPoint = "vertexMain",
-                                        .bufferCount = vertexBufferLayouts.size(),
-                                        .buffers = vertexBufferLayouts.data()},
+            .vertex = wgpu::VertexState{.module = desc.shaderAsset->GetShaderModule(),
+                                        .entryPoint = desc.vertexEntry.c_str(),
+                                        .bufferCount = vertexLayouts.size(),
+                                        .buffers = vertexLayouts.data()},
             .primitive = desc.primitive,
             .fragment = &fragment,
         });

--- a/core/render/PipelineManager.h
+++ b/core/render/PipelineManager.h
@@ -2,6 +2,7 @@
 #include "LayoutCache.h"
 #include "Material.h"
 #include "Mesh.h"
+#include "VertexLayoutManager.h"
 #include "ResourcePool.h"
 #include "ShaderAsset.h"
 #include "render.h"
@@ -11,15 +12,22 @@ namespace core::render {
 struct PipelineDesc {
     wgpu::StringView label = {};
     AssetView<ShaderAsset> shaderAsset;
-    VertexType vertexType = VertexType::None;
+    std::string vertexEntry;
+    std::string fragmentEntry;
     wgpu::PrimitiveState primitive = wgx::PrimitiveState::kDefault;
     wgpu::BlendState blendState = wgx::BlendState::kReplace;
+    MeshAssetFormat::MeshVertexState vertexState;
 
     bool operator==(const PipelineDesc& other) const {
         if (shaderAsset != other.shaderAsset) {
             return false;
         }
-        if (vertexType != other.vertexType) {
+        if (vertexEntry != other.vertexEntry)
+        {
+            return false;
+        }
+        if (fragmentEntry != other.fragmentEntry)
+        {
             return false;
         }
 
@@ -37,7 +45,6 @@ struct PipelineDescHash {
     std::size_t operator()(const PipelineDesc& k) const {
         size_t seed = 0;
         wgx::hash_combine(seed, std::hash<Handle>{}(k.shaderAsset.handle));
-        wgx::hash_combine(seed, std::hash<int>{}(static_cast<int>(k.vertexType)));
         wgx::hash_combine(seed, wgx::Hash(k.primitive));
         wgx::hash_combine(seed, wgx::Hash(k.blendState));
         return seed;
@@ -55,6 +62,7 @@ class PipelineManager {
 
   private:
     Device* m_device;
+    VertexLayoutManager m_vertexLayoutManager;
 
     wgpu::BindGroupLayout m_globalBindGroupLayout;
 

--- a/core/render/PipelineManager.h
+++ b/core/render/PipelineManager.h
@@ -29,11 +29,13 @@ struct PipelineDesc {
         {
             return false;
         }
-
         if (!wgx::Equals(primitive, other.primitive)) {
             return false;
         }
         if (!wgx::Equals(blendState, other.blendState)) {
+            return false;
+        }
+        if (vertexState != other.vertexState) {
             return false;
         }
         return true;

--- a/core/render/PipelineManager.h
+++ b/core/render/PipelineManager.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "LayoutCache.h"
-#include "Material.h"
 #include "Mesh.h"
 #include "VertexLayoutManager.h"
 #include "ResourcePool.h"

--- a/core/render/RenderGraph.cpp
+++ b/core/render/RenderGraph.cpp
@@ -53,17 +53,17 @@ void core::render::RenderGraph::Execute(FrameContext& frameContext) {
 
     auto packets = frameContext.GetQueue();
     for (auto& p : packets) {
-        wgpu::RenderPipeline pipeline = m_pipelineManager->GetRenderPipeline(PipelineDesc{
-            .shaderAsset = p.material->GetShader(),
-            .vertexType = VertexType::StandardMesh,
-        });
-        pass.SetPipeline(pipeline);
-        pass.SetVertexBuffer(0, p.vertexBuffer);
+        pass.SetPipeline(p.pipeline);
+        for (uint i = 0; i < p.bufferRanges.size(); ++i) {
+            const auto bufferRange = p.bufferRanges[i];
+            pass.SetVertexBuffer(i, p.vertexBuffer, bufferRange.offset, bufferRange.size);
+        }
+
         pass.SetIndexBuffer(p.indexBuffer, wgpu::IndexFormat::Uint32);
         pass.SetBindGroup(1, p.material->GetBindGroup());
-        //pass.SetBindGroup(2, m_tempBindGroup.bindGroup);
+        // pass.SetBindGroup(2, m_tempBindGroup.bindGroup);
 
-        pass.DrawIndexed(p.indexCount);
+        pass.DrawIndexed(p.indexCount, 1, p.indexStart);
     }
 
     pass.End();

--- a/core/render/RenderGraph.h
+++ b/core/render/RenderGraph.h
@@ -10,10 +10,12 @@
 namespace core::render {
 
 struct RenderPacket {
+    wgpu::RenderPipeline pipeline;
     wgpu::Buffer vertexBuffer;
     wgpu::Buffer indexBuffer;
-    size_t indexCount;
-
+    std::span<const MeshAssetFormat::BufferRange> bufferRanges;
+    uint32_t indexStart = 0; 
+    uint32_t indexCount = 0;
     AssetView<Material> material;
 };
 

--- a/core/render/ShaderAsset.cpp
+++ b/core/render/ShaderAsset.cpp
@@ -1,81 +1,73 @@
+#include <ranges>
+
 #include "ShaderAsset.h"
 
 namespace core::render {
 
 ShaderAsset ShaderAsset::Create(wgpu::ShaderModule shaderModule,
-                                sa::ShaderVisibility shaderStage,
-                                ShaderReflectionData reflection,
+                                std::unique_ptr<ShaderAssetFormat> shaderAssetFormat,
+                                ShaderReflection shaderReflection,
                                 std::array<wgpu::BindGroupLayout, 4> bindGroupLayouts) {
-    wgpu::ShaderModule vertexModule = nullptr;
-    wgpu::ShaderModule fragmentModule = nullptr;
-    wgpu::ShaderModule computeModule = nullptr;
-    if (static_cast<uint8_t>(shaderStage) & static_cast<uint8_t>(sa::ShaderVisibility::Vertex)) {
-        vertexModule = shaderModule;
-    }
-    if (static_cast<uint8_t>(shaderStage) & static_cast<uint8_t>(sa::ShaderVisibility::Fragment)) {
-        fragmentModule = shaderModule;
-    }
-    if (static_cast<uint8_t>(shaderStage) & static_cast<uint8_t>(sa::ShaderVisibility::Compute)) {
-        computeModule = shaderModule;
-    }
 
-    return ShaderAsset(vertexModule, fragmentModule, computeModule, shaderStage, reflection,
+    return ShaderAsset(shaderModule, std::move(shaderAssetFormat), shaderReflection,
                        bindGroupLayouts);
 }
 
-std::expected<ShaderReflectionData, Error> ShaderReflectionData::MergeReflectionData(
-    const ShaderReflectionData& a,
-                                                               const ShaderReflectionData& b) {
-    using sa = core::ShaderAssetFormat;
+const std::span<const ShaderReflection::Binding> ShaderReflection::GetGroup(uint32_t setIdx) const {
+    return std::span<const ShaderAssetFormat::Binding>(
+        m_shaderAssetFormat->bindings.begin() + (groups[setIdx].offset), groups[setIdx].count);
+};
 
-    ShaderReflectionData mergedData;
-    mergedData.bindings.reserve(a.bindings.size());
-    auto aIt = a.bindings.begin();
-    auto bIt = b.bindings.begin();
-
-    while (aIt != a.bindings.end() && bIt != b.bindings.end()) {
-        if (aIt->set == bIt->set && aIt->binding == bIt->binding) {
-            if (aIt->resourceType != bIt->resourceType) {
-                return std::unexpected(Error::AssetParsing(
-                    "Binding Conflict: Same binding index but incompatible resource types!"));
-            }
-            BindingInfo mergedBinding = *aIt;
-            mergedBinding.visibility = static_cast<sa::ShaderVisibility>(
-                static_cast<uint8_t>(aIt->visibility) | static_cast<uint8_t>(bIt->visibility));
-            mergedData.bindings.push_back(mergedBinding);
-            ++aIt;
-            ++bIt;
-        } else if (aIt->set < bIt->set || (aIt->set == bIt->set && aIt->binding < bIt->binding)) {
-            mergedData.bindings.push_back(*aIt);
-            ++aIt;
-        } else {
-            mergedData.bindings.push_back(*bIt);
-            ++bIt;
-        }
-    }
-
-    while (aIt != a.bindings.end()) {
-        mergedData.bindings.push_back(*aIt);
-        ++aIt;
-    }
-    while (bIt != b.bindings.end()) {
-        mergedData.bindings.push_back(*bIt);
-        ++bIt;
-    }
-
-    mergedData.groups = {};
-    for (uint32_t i = 0; i < mergedData.bindings.size(); ++i) {
-        const auto& binding = mergedData.bindings[i];
-
-        if (mergedData.groups[binding.set].count == 0) {
-            mergedData.groups[binding.set].offset = i;
-        }
-        mergedData.groups[binding.set].count++;
-    }
-    // TODO!(Now mergedData.materialVariables parsing logic is not implemented. it should be append
-    // after that)
-
-    return mergedData;
+const std::span<const ShaderReflection::Binding> ShaderReflection::GetAllBindings() const {
+    return m_shaderAssetFormat->bindings;
 }
+
+const std::span<const MaterialVariableInfo> ShaderReflection::GetMaterialVariableInfos() const {
+    // TODO!
+    assert(false && "GetMaterialVariableInfos is not implemented");
+    return {};
+}
+
+const std::span<const ShaderReflection::Parameter> ShaderReflection::GetEntryInput(
+    const std::string& name) const {
+    auto it = std::ranges::find(m_shaderAssetFormat->entryPoints, name, [this](const auto& entry) {
+        return GetNameByIndex(entry.nameIdx);
+    });
+    if (it == m_shaderAssetFormat->entryPoints.end()) {
+        return std::span<const ShaderReflection::Parameter>();
+    }
+
+    return std::span(m_shaderAssetFormat->parameters.data() + it->ioStartIndex, it->ioCount);
+}
+
+std::string_view ShaderReflection::GetNameByIndex(uint32_t idx) const {
+    return m_nameTable[idx];
+}
+
+ShaderReflection ShaderReflection::Create(ShaderAssetFormat* shaderAssetFormat) {
+    auto nametable = shaderAssetFormat->nameTableData | std::views::split('\0') |
+                     std::views::transform([](auto&& s) {
+                         return std::string_view(std::ranges::data(s), std::ranges::size(s));
+                     }) |
+                     std::ranges::to<std::vector>();
+
+    std::array<GroupRange, 4> groups;
+    const auto& bindings = shaderAssetFormat->bindings;
+    for (size_t i = 0; i < bindings.size(); ++i) {
+        const ShaderAssetFormat::Binding& binding = bindings[i];
+
+        uint32_t size = 0;
+        if (binding.resourceType == ShaderAssetFormat::ResourceType::UniformBuffer) {
+            size = binding.resource.buffer.bufferSize;
+        }
+
+        if (groups[binding.set].count == 0) {
+            groups[binding.set].offset = i;
+        }
+        groups[binding.set].count++;
+    }
+    return ShaderReflection(shaderAssetFormat, std::move(nametable), groups);
+}
+
 
 }  // namespace core::render

--- a/core/render/ShaderAsset.cpp
+++ b/core/render/ShaderAsset.cpp
@@ -13,22 +13,22 @@ ShaderAsset ShaderAsset::Create(wgpu::ShaderModule shaderModule,
                        bindGroupLayouts);
 }
 
-const std::span<const ShaderReflection::Binding> ShaderReflection::GetGroup(uint32_t setIdx) const {
+std::span<const ShaderReflection::Binding> ShaderReflection::GetGroup(uint32_t setIdx) const {
     return std::span<const ShaderAssetFormat::Binding>(
         m_shaderAssetFormat->bindings.begin() + (groups[setIdx].offset), groups[setIdx].count);
 };
 
-const std::span<const ShaderReflection::Binding> ShaderReflection::GetAllBindings() const {
+std::span<const ShaderReflection::Binding> ShaderReflection::GetAllBindings() const {
     return m_shaderAssetFormat->bindings;
 }
 
-const std::span<const MaterialVariableInfo> ShaderReflection::GetMaterialVariableInfos() const {
+std::span<const MaterialVariableInfo> ShaderReflection::GetMaterialVariableInfos() const {
     // TODO!
     assert(false && "GetMaterialVariableInfos is not implemented");
     return {};
 }
 
-const std::span<const ShaderReflection::Parameter> ShaderReflection::GetEntryInput(
+std::span<const ShaderReflection::Parameter> ShaderReflection::GetEntryInput(
     const std::string& name) const {
     auto it = std::ranges::find(m_shaderAssetFormat->entryPoints, name, [this](const auto& entry) {
         return GetNameByIndex(entry.nameIdx);

--- a/core/render/ShaderAsset.h
+++ b/core/render/ShaderAsset.h
@@ -2,23 +2,13 @@
 #include <dawn/webgpu_cpp.h>
 #include <array>
 #include <expected>
+#include <memory>
 
 #include "Common.h"
 #include "ShaderAssetFormat.h"
 #include "render.h"
 
-
 namespace core::render {
-
-struct BindingInfo {
-    using Fmt = ShaderAssetFormat;
-    uint32_t set;
-    uint32_t binding;
-    PropertyId id;
-    Fmt::ResourceType resourceType;
-    Fmt::ShaderVisibility visibility;
-    Fmt::Resource resource = {.buffer = {0}};
-};
 
 struct MaterialVariableInfo {
     PropertyId id;
@@ -26,33 +16,41 @@ struct MaterialVariableInfo {
     size_t size;
 };
 
-struct ShaderReflectionData {
-    std::vector<BindingInfo> bindings;
-    std::vector<MaterialVariableInfo> materialVariables;
+class ShaderReflection {
+  public:
+    using Binding = ShaderAssetFormat::Binding;
+    using Parameter = ShaderAssetFormat::ShaderParameter;
+
+    static ShaderReflection Create(ShaderAssetFormat* shaderAssetFormat);
+
+
     size_t materialUniformSize = 0;
-    ShaderAssetFormat::ShaderVisibility entryShaderStage;
 
     struct GroupRange {
         uint32_t offset = 0;
         uint32_t count = 0;
     };
 
+
+    const std::span<const Binding> GetGroup(uint32_t setIdx) const;
+    const std::span<const Binding> GetAllBindings() const;
+
+    const std::span<const MaterialVariableInfo> GetMaterialVariableInfos() const;
+
+    const std::span<const ShaderAssetFormat::ShaderParameter> GetEntryInput(
+        const std::string& name) const;
+
+  private:
+    ShaderReflection(ShaderAssetFormat* shaderAssetFormat,
+                     std::vector<std::string_view>&& nametable,
+                     std::array<GroupRange, 4> groups)
+        : m_shaderAssetFormat(shaderAssetFormat), m_nameTable(std::move(nametable)), groups(groups) {}
+
+    const ShaderAssetFormat* m_shaderAssetFormat;
+    std::vector<std::string_view> m_nameTable;
     std::array<GroupRange, 4> groups;
 
-    // Merge two reflection data by combining their bindings and visibilities
-    static std::expected<ShaderReflectionData, Error> MergeReflectionData(
-        const ShaderReflectionData& a,
-        const ShaderReflectionData& b);
-
-    const std::span<const BindingInfo> GetGroup(uint32_t setIdx) const {
-        return std::span<const BindingInfo>(bindings.begin() + (groups[setIdx].offset),
-                                            groups[setIdx].count);
-    };
-    const std::span<const BindingInfo> GetAllBindings() const { return bindings; }
-
-    const std::span<const MaterialVariableInfo> GetMaterialVariableInfos() const {
-        return materialVariables;
-    }
+    std::string_view GetNameByIndex(uint32_t idx) const;
 };
 
 class ShaderAsset {
@@ -68,13 +66,11 @@ class ShaderAsset {
     ~ShaderAsset() = default;
 
     static ShaderAsset Create(wgpu::ShaderModule shaderModule,
-                              sa::ShaderVisibility shaderStage,
-                              ShaderReflectionData reflection,
+                              std::unique_ptr<ShaderAssetFormat> shaderAssetFormat,
+                              ShaderReflection shaderReflection,
                               std::array<wgpu::BindGroupLayout, 4> bindGroupLayouts);
 
-    const wgpu::ShaderModule& GetVertexModule() const { return m_vertexModule; }
-    const wgpu::ShaderModule& GetFragmentModule() const { return m_fragmentModule; }
-    const wgpu::ShaderModule& GetComputeModule() const { return m_computeModule; }
+    const wgpu::ShaderModule& GetShaderModule() const { return m_shaderModule; }
 
     wgpu::BindGroupLayout GetBindGroupLayout(uint32_t setNumber) const {
         return m_bindGroupLayouts[setNumber];
@@ -84,31 +80,23 @@ class ShaderAsset {
         return m_bindGroupLayouts;
     }
 
-    bool IsValidRenderShader() {
-        return m_vertexModule != nullptr && m_fragmentModule != nullptr &&
-               m_shaderStage & (sa::ShaderVisibility::Vertex | sa::ShaderVisibility::Fragment);
-    }
-    const ShaderReflectionData& GetReflection() const { return m_reflection; }
+    const ShaderReflection& GetReflection() const { return m_reflection; }
 
   private:
-    ShaderAsset(wgpu::ShaderModule vertex,
-                wgpu::ShaderModule fragment,
-                wgpu::ShaderModule compute,
-                sa::ShaderVisibility shaderStage,
-                ShaderReflectionData reflection,
+    ShaderAsset(wgpu::ShaderModule shaderModule,
+                std::unique_ptr<ShaderAssetFormat> shaderAssetFormat,
+                ShaderReflection reflection,
+
                 std::array<wgpu::BindGroupLayout, 4> bindGroupLayout)
-        : m_vertexModule(vertex),
-          m_fragmentModule(fragment),
-          m_computeModule(compute),
-          m_shaderStage(shaderStage),
-          m_reflection(std::move(reflection)),
+        : m_shaderModule(shaderModule),
+          m_shaderAssetFormat(std::move(shaderAssetFormat)),
+          m_reflection(reflection),
           m_bindGroupLayouts(bindGroupLayout) {}
 
-    wgpu::ShaderModule m_vertexModule = nullptr;
-    wgpu::ShaderModule m_fragmentModule = nullptr;
-    wgpu::ShaderModule m_computeModule = nullptr;
+    wgpu::ShaderModule m_shaderModule = nullptr;
     std::array<wgpu::BindGroupLayout, 4> m_bindGroupLayouts;
-    sa::ShaderVisibility m_shaderStage = sa::ShaderVisibility::None;
-    ShaderReflectionData m_reflection;
+
+    std::unique_ptr<ShaderAssetFormat> m_shaderAssetFormat;
+    ShaderReflection m_reflection;
 };
 }  // namespace core::render

--- a/core/render/ShaderAsset.h
+++ b/core/render/ShaderAsset.h
@@ -32,12 +32,12 @@ class ShaderReflection {
     };
 
 
-    const std::span<const Binding> GetGroup(uint32_t setIdx) const;
-    const std::span<const Binding> GetAllBindings() const;
+    std::span<const Binding> GetGroup(uint32_t setIdx) const;
+    std::span<const Binding> GetAllBindings() const;
 
-    const std::span<const MaterialVariableInfo> GetMaterialVariableInfos() const;
+    std::span<const MaterialVariableInfo> GetMaterialVariableInfos() const;
 
-    const std::span<const ShaderAssetFormat::ShaderParameter> GetEntryInput(
+    std::span<const ShaderAssetFormat::ShaderParameter> GetEntryInput(
         const std::string& name) const;
 
   private:

--- a/core/render/ShaderManager.cpp
+++ b/core/render/ShaderManager.cpp
@@ -34,17 +34,17 @@ ShaderManager::ShaderManager(Device* device, AssetManager* assetRepo, LayoutCach
 
     ShaderAssetFormat& blob = blobOrError.value();
 
-    render::ShaderAsset vtxShader = CreateFromShaderSource(std::move(blob));
+    render::ShaderAsset shader = CreateFromShaderSource(std::move(blob));
 
-    m_standardShader = m_assetRepo->StoreShaderAsset(std::move(vtxShader));
+    m_standardShader = m_assetRepo->StoreShaderAsset(std::move(shader));
 }
 
-ShaderAsset ShaderManager::CreateFromShaderSource(ShaderAssetFormat&& shaderBlob) {
-    std::string_view wgslCode(reinterpret_cast<const char*>(shaderBlob.code.data()),
-                              shaderBlob.code.size());
+ShaderAsset ShaderManager::CreateFromShaderSource(ShaderAssetFormat&& shaderAsset) {
+    std::string_view wgslCode(reinterpret_cast<const char*>(shaderAsset.code.data()),
+                              shaderAsset.code.size());
     wgpu::ShaderModule shaderModule = m_device->CreateShaderModuleFromWGSL(wgslCode);
 
-    auto shaderAssetFormat = std::make_unique<ShaderAssetFormat>(std::move(shaderBlob));
+    auto shaderAssetFormat = std::make_unique<ShaderAssetFormat>(std::move(shaderAsset));
     ShaderReflection reflection = ShaderReflection::Create(shaderAssetFormat.get());
 
     std::array<wgpu::BindGroupLayout, 4> bindGroupLayouts = CreateGroupLayouts(reflection);
@@ -71,7 +71,7 @@ Handle ShaderManager::LoadShader(core::importer::ShaderImportResult&& shaderResu
         return it->second;
     }
     core::render::ShaderAsset shaderAsset =
-        CreateFromShaderSource(std::move(shaderResult.shaderBlob));
+        CreateFromShaderSource(std::move(shaderResult.shaderAsset));
     Handle handle = m_assetRepo->StoreShaderAsset(std::move(shaderAsset));
     m_shaderCache[shaderResult.assetPath] = handle;
     return handle;

--- a/core/render/ShaderManager.cpp
+++ b/core/render/ShaderManager.cpp
@@ -1,17 +1,16 @@
 #include "ShaderManager.h"
 #include <ranges>
-#include "asset/StandardPBR_FS.h"
-#include "asset/StandardPBR_VS.h"
+#include "asset/StandardPBR.h"
 #include "util.h"
 
 namespace core::render {
 
 std::array<wgpu::BindGroupLayout, 4> ShaderManager::CreateGroupLayouts(
-    const core::render::ShaderReflectionData& reflection) {
+    const core::render::ShaderReflection& reflection) {
     std::array<wgpu::BindGroupLayout, 4> bindGroupLayouts;
 
     for (uint32_t i = 0; i < 4; ++i) {
-        std::span<const BindingInfo> bindings = reflection.GetGroup(i);
+        const std::span<const ShaderAssetFormat::Binding> bindings = reflection.GetGroup(i);
         std::vector<wgpu::BindGroupLayoutEntry> entries =
             bindings | std::views::transform(util::MapBindingInfoToWgpu) |
             std::ranges::to<std::vector>();
@@ -27,87 +26,31 @@ std::array<wgpu::BindGroupLayout, 4> ShaderManager::CreateGroupLayouts(
 
 ShaderManager::ShaderManager(Device* device, AssetManager* assetRepo, LayoutCache* layoutCache)
     : m_device(device), m_assetRepo(assetRepo), m_layoutCache(layoutCache) {
-    auto vtxBlobOrError = ShaderAssetFormat::LoadFromMemory(kStandardPBR_VS_Data)
-                              .and_then(core::importer::ShdrImporter::ShdrConvert);
-    auto frgBlobOrError = ShaderAssetFormat::LoadFromMemory(kStandardPBR_FS_Data)
-                              .and_then(core::importer::ShdrImporter::ShdrConvert);
+    auto blobOrError = ShaderAssetFormat::LoadFromMemory(kStandardPBR_Data);
 
-    if (!vtxBlobOrError.has_value()) {
-        assert(false && "Failed to load standard PBR vertex shader");
-    }
-    if (!frgBlobOrError.has_value()) {
-        assert(false && "Failed to load standard PBR fragment shader");
-    }
-
-    core::importer::ShaderBlob& vtxBlob = vtxBlobOrError.value();
-    core::importer::ShaderBlob& frgBlob = frgBlobOrError.value();
-
-    // ShaderManager's layout caching logic relies on reflection data. Merging reflections reduces
-    // unused layout cache entries.
-    auto reflectionOrError =
-        render::ShaderReflectionData::MergeReflectionData(vtxBlob.reflection, frgBlob.reflection);
-    if (!reflectionOrError.has_value()) {
-        assert(false && "Failed to load standard PBR shader");
-    }
-    vtxBlob.reflection = reflectionOrError.value();
-    vtxBlob.reflection.entryShaderStage = ShaderAssetFormat::ShaderVisibility::Vertex;
-    frgBlob.reflection = reflectionOrError.value();
-    frgBlob.reflection.entryShaderStage = ShaderAssetFormat::ShaderVisibility::Fragment;
-
-    render::ShaderAsset vtxShader = CreateFromShaderSource(vtxBlob);
-    render::ShaderAsset frgShader = CreateFromShaderSource(frgBlob);
-
-    auto renderShaderOrError = MergeShaderAsset(vtxShader, frgShader);
-
-    if (!renderShaderOrError.has_value()) {
+    if (!blobOrError.has_value()) {
         assert(false && "Failed to load standard PBR shader");
     }
 
-    m_standardShader = m_assetRepo->StoreShaderAsset(std::move(renderShaderOrError.value()));
+    ShaderAssetFormat& blob = blobOrError.value();
+
+    render::ShaderAsset vtxShader = CreateFromShaderSource(std::move(blob));
+
+    m_standardShader = m_assetRepo->StoreShaderAsset(std::move(vtxShader));
 }
 
-ShaderAsset ShaderManager::CreateFromShaderSource(const core::importer::ShaderBlob& shaderBlob) {
-    const auto& reflection = shaderBlob.reflection;
-
-    std::string_view wgslCode(reinterpret_cast<const char*>(shaderBlob.shaderCode.data()),
-                              shaderBlob.shaderCode.size());
+ShaderAsset ShaderManager::CreateFromShaderSource(ShaderAssetFormat&& shaderBlob) {
+    std::string_view wgslCode(reinterpret_cast<const char*>(shaderBlob.code.data()),
+                              shaderBlob.code.size());
     wgpu::ShaderModule shaderModule = m_device->CreateShaderModuleFromWGSL(wgslCode);
 
+    auto shaderAssetFormat = std::make_unique<ShaderAssetFormat>(std::move(shaderBlob));
+    ShaderReflection reflection = ShaderReflection::Create(shaderAssetFormat.get());
+
     std::array<wgpu::BindGroupLayout, 4> bindGroupLayouts = CreateGroupLayouts(reflection);
 
-    return ShaderAsset::Create(shaderModule, reflection.entryShaderStage, reflection,
+    return ShaderAsset::Create(shaderModule, std::move(shaderAssetFormat), reflection,
                                bindGroupLayouts);
-}
-
-std::expected<ShaderAsset, Error> ShaderManager::MergeShaderAsset(const ShaderAsset& a,
-                                                                 const ShaderAsset& b) {
-    using Fmt = ShaderAssetFormat;
-    if (a.m_shaderStage & b.m_shaderStage) {
-        return std::unexpected(
-            Error::AssetParsing("Cannot merge two ShaderAssets with the same shader stage."));
-    }
-
-    wgpu::ShaderModule vertexModule =
-        a.m_vertexModule != nullptr ? a.m_vertexModule : b.m_vertexModule;
-    wgpu::ShaderModule fragmentModule =
-        a.m_fragmentModule != nullptr ? a.m_fragmentModule : b.m_fragmentModule;
-    wgpu::ShaderModule computeModule =
-        a.m_computeModule != nullptr ? a.m_computeModule : b.m_computeModule;
-    Fmt::ShaderVisibility shaderStage = static_cast<Fmt::ShaderVisibility>(
-        static_cast<uint8_t>(a.m_shaderStage) | static_cast<uint8_t>(b.m_shaderStage));
-
-    auto reflectionOrError =
-        ShaderReflectionData::MergeReflectionData(a.GetReflection(), b.GetReflection());
-
-    if (reflectionOrError.has_value() == false) {
-        return std::unexpected(reflectionOrError.error());
-    }
-
-    const auto& reflection = reflectionOrError.value();
-    std::array<wgpu::BindGroupLayout, 4> bindGroupLayouts = CreateGroupLayouts(reflection);
-
-    return ShaderAsset(vertexModule, fragmentModule, computeModule, shaderStage, reflection,
-                       bindGroupLayouts);
 }
 
 AssetView<ShaderAsset> ShaderManager::GetShaderAsset(Handle shaderHandle) {
@@ -122,12 +65,13 @@ AssetView<ShaderAsset> ShaderManager::GetShader(const AssetPath& shaderPath) {
     return m_assetRepo->GetShaderAsset(m_standardShader);
 }
 
-Handle ShaderManager::LoadShader(const core::importer::ShaderImportResult& shaderResult) {
+Handle ShaderManager::LoadShader(core::importer::ShaderImportResult&& shaderResult) {
     auto it = m_shaderCache.find(shaderResult.assetPath);
     if (it != m_shaderCache.end()) {
         return it->second;
     }
-    core::render::ShaderAsset shaderAsset = CreateFromShaderSource(shaderResult.shaderBlob);
+    core::render::ShaderAsset shaderAsset =
+        CreateFromShaderSource(std::move(shaderResult.shaderBlob));
     Handle handle = m_assetRepo->StoreShaderAsset(std::move(shaderAsset));
     m_shaderCache[shaderResult.assetPath] = handle;
     return handle;

--- a/core/render/ShaderManager.h
+++ b/core/render/ShaderManager.h
@@ -11,7 +11,7 @@ class ShaderManager {
   public:
     ShaderManager(Device* device, AssetManager* assetRepo, LayoutCache* layoutCache);
 
-    ShaderAsset CreateFromShaderSource(ShaderAssetFormat&& shaderBlob);
+    ShaderAsset CreateFromShaderSource(ShaderAssetFormat&& shaderAsset);
 
     Handle LoadShader(core::importer::ShaderImportResult&& shaderResult);
     AssetView<ShaderAsset> GetShader(const AssetPath& shaderPath);

--- a/core/render/ShaderManager.h
+++ b/core/render/ShaderManager.h
@@ -11,17 +11,16 @@ class ShaderManager {
   public:
     ShaderManager(Device* device, AssetManager* assetRepo, LayoutCache* layoutCache);
 
-    ShaderAsset CreateFromShaderSource(const core::importer::ShaderBlob &shaderBlob);
-    std::expected<ShaderAsset, Error> MergeShaderAsset(const ShaderAsset& a, const ShaderAsset& b);
+    ShaderAsset CreateFromShaderSource(ShaderAssetFormat&& shaderBlob);
 
-    Handle LoadShader(const core::importer::ShaderImportResult& shaderResult);
+    Handle LoadShader(core::importer::ShaderImportResult&& shaderResult);
     AssetView<ShaderAsset> GetShader(const AssetPath& shaderPath);
     AssetView<ShaderAsset> GetShaderAsset(Handle shaderHandle);
     AssetView<ShaderAsset> GetStandardShader() { return m_assetRepo->GetShaderAsset(m_standardShader); }
 
   private:
     std::array<wgpu::BindGroupLayout, 4> CreateGroupLayouts(
-        const core::render::ShaderReflectionData& reflection);
+        const core::render::ShaderReflection& reflection);
     Device* m_device;
     AssetManager* m_assetRepo;
     LayoutCache* m_layoutCache;

--- a/core/render/VertexLayoutManager.cpp
+++ b/core/render/VertexLayoutManager.cpp
@@ -1,0 +1,32 @@
+#include "VertexLayoutManager.h"
+#include <ranges>
+#include <span>
+
+core::Handle core::render::VertexLayoutManager::GetVertexLayout(
+    const wgx::VertexBufferLayout& layout) {
+    auto it = std::ranges::find_if(
+        m_layoutCache, [layout](const std::pair<wgx::VertexBufferLayout, Handle>& pair) {
+            return pair.first == layout;
+        });
+    if (it != m_layoutCache.end()) {
+        return it->second;
+    }
+
+    VertexLayout newLayout;
+    newLayout.m_attributes = layout.attributes | std::views::transform([](auto att) {
+                                 return wgpu::VertexAttribute{
+                                     .format = att.format,
+                                     .offset = att.offset,
+                                     .shaderLocation = att.shaderLocation,
+                                 };
+                             }) |
+                             std::ranges::to<std::vector>();
+    newLayout.m_layout.arrayStride = layout.arrayStride;
+    newLayout.m_layout.stepMode = layout.stepMode;
+    newLayout.m_layout.attributes = newLayout.m_attributes.data();
+    newLayout.m_layout.attributeCount = newLayout.m_attributes.size();
+
+    core::Handle handle = m_vertexLayouts.Attach(std::move(newLayout));
+    m_layoutCache.push_back({layout, handle});
+    return handle;
+}

--- a/core/render/VertexLayoutManager.cpp
+++ b/core/render/VertexLayoutManager.cpp
@@ -5,7 +5,7 @@
 core::Handle core::render::VertexLayoutManager::GetVertexLayout(
     const wgx::VertexBufferLayout& layout) {
     auto it = std::ranges::find_if(
-        m_layoutCache, [layout](const std::pair<wgx::VertexBufferLayout, Handle>& pair) {
+        m_layoutCache, [&layout](const std::pair<wgx::VertexBufferLayout, Handle>& pair) {
             return pair.first == layout;
         });
     if (it != m_layoutCache.end()) {

--- a/core/render/VertexLayoutManager.h
+++ b/core/render/VertexLayoutManager.h
@@ -1,0 +1,38 @@
+#pragma once
+#include "ResourcePool.h"
+#include "VertexLayout.h"
+#include "wgx/types.h"
+
+namespace core::render {
+
+class VertexLayout {
+    friend class VertexLayoutManager;
+
+  public:
+    wgpu::VertexBufferLayout GetLayout() { return m_layout; }
+
+  private:
+    VertexLayout() = default;
+    wgpu::VertexBufferLayout m_layout;
+    std::vector<wgpu::VertexAttribute> m_attributes;
+};
+
+class VertexLayoutManager {
+  public:
+    VertexLayoutManager() = default;
+
+    core::Handle GetVertexLayout(const wgx::VertexBufferLayout& layout);
+    AssetView<VertexLayout> GetVertexLayout(core::Handle handle) { return {m_vertexLayouts.Get(handle), handle}; }
+
+    struct VertexAttributeKey {
+        wgpu::VertexFormat format = {};
+        uint64_t offset;
+        uint32_t shaderLocation;
+    };
+
+  private:
+
+    std::vector<std::pair<wgx::VertexBufferLayout, Handle>> m_layoutCache;
+    ResourcePool<VertexLayout> m_vertexLayouts;
+};
+}  // namespace core::render

--- a/core/render/util.cpp
+++ b/core/render/util.cpp
@@ -114,7 +114,8 @@ static wgpu::ShaderStage MapStageToWgpu(ShaderAssetFormat::ShaderVisibility visi
     }
 }
 
-static wgpu::SamplerBindingLayout MapBindingToSampler(const render::BindingInfo& binding) {
+static wgpu::SamplerBindingLayout MapBindingToSampler(
+    const render::ShaderReflection::Binding& binding) {
     const auto& sampler = binding.resource.sampler;
     switch (sampler.type) {
         case ShaderAssetFormat::SamplerType::Filtering:
@@ -142,7 +143,7 @@ static wgpu::SamplerBindingLayout MapBindingToSampler(const render::BindingInfo&
     }
 }
 
-static wgpu::TextureBindingLayout MapBindingToTexture(render::BindingInfo& binding) {
+static wgpu::TextureBindingLayout MapBindingToTexture(render::ShaderReflection::Binding& binding) {
     const auto& texture = binding.resource.texture;
 
     wgpu::TextureBindingLayout layout{};
@@ -207,7 +208,8 @@ static wgpu::TextureBindingLayout MapBindingToTexture(render::BindingInfo& bindi
     return layout;
 }
 
-wgpu::BindGroupLayoutEntry core::util::MapBindingInfoToWgpu(render::BindingInfo binding) {
+wgpu::BindGroupLayoutEntry core::util::MapBindingInfoToWgpu(
+    render::ShaderReflection::Binding binding) {
     wgpu::BindGroupLayoutEntry entry{
         .binding = binding.binding,
         .visibility = MapStageToWgpu(binding.visibility),

--- a/core/render/util.h
+++ b/core/render/util.h
@@ -28,7 +28,7 @@ wgpu::Surface CreateSurfaceForWGPU(wgpu::Instance instance, Window& window);
 bool IsSRGB(wgpu::TextureFormat format);
 wgpu::TextureFormat SelectSurfaceFormat(const wgpu::Adapter& adapter, const wgpu::Surface& surface);
 
-wgpu::BindGroupLayoutEntry MapBindingInfoToWgpu(core::render::BindingInfo binding);
+wgpu::BindGroupLayoutEntry MapBindingInfoToWgpu(core::render::ShaderReflection::Binding binding);
 
 wgpu::TextureFormat ConvertTextureFormatWgpu(core::TextureFormat format);
 wgpu::TextureDimension ConvertTextureDimensionWgpu(core::TextureDimension dimension);

--- a/core/wgx/types.h
+++ b/core/wgx/types.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <dawn/webgpu_cpp.h>
+#include <ranges>
+#include <vector>
+#include <algorithm>
+
+namespace wgx {
+struct VertexAttribute {
+    wgpu::VertexFormat format = {};
+    uint64_t offset;
+    uint32_t shaderLocation;
+
+    bool operator==(const VertexAttribute&) const = default;
+};
+
+struct VertexBufferLayout {
+    wgpu::VertexStepMode stepMode = wgpu::VertexStepMode::Undefined;
+    uint64_t arrayStride;
+    std::vector<VertexAttribute> attributes;
+
+    bool operator==(const VertexBufferLayout& other) const {
+        if (stepMode != other.stepMode || arrayStride != other.arrayStride) {
+            return false;
+        }
+        return std::ranges::equal(attributes, other.attributes);
+    }
+};
+}  // namespace wgx

--- a/shader/CMakeLists.txt
+++ b/shader/CMakeLists.txt
@@ -6,7 +6,7 @@ target_compile_features(shader PUBLIC cxx_std_23)
 target_link_libraries(shader PUBLIC slang::slang common)
 target_include_directories(shader PUBLIC "./")
 
-add_executable(shaderCompiler "main.cpp")
+add_executable(shaderCompiler "main.cpp" "util.h" "util.cpp")
 target_link_libraries(shaderCompiler PRIVATE  shader)
 
 add_custom_command(TARGET shaderCompiler  POST_BUILD
@@ -18,7 +18,7 @@ add_custom_command(TARGET shaderCompiler  POST_BUILD
 
 enable_testing()
 
-add_executable(shaderTest "test/test.cpp" "test/ShaderInterop.h" "test/test.h")
+add_executable(shaderTest "test/test.cpp" "test/ShaderInterop.h" "test/test.h" "test/ParameterTest.h" "test/ParameterTest.cpp" "util.h" "util.cpp")
 target_link_libraries(shaderTest PRIVATE  shader)
 target_link_libraries(shaderTest PRIVATE GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
 

--- a/shader/SlangCompiler.cpp
+++ b/shader/SlangCompiler.cpp
@@ -1,8 +1,11 @@
+
 #include <algorithm>
 #include <filesystem>
 #include <print>
 #include <ranges>
 
+#include <slang-com-helper.h>
+#include <slang-com-ptr.h>
 #include "SlangCompiler.h"
 
 using Slang::ComPtr;
@@ -36,10 +39,8 @@ std::expected<SlangCompiler, Error> SlangCompiler::Create(const SlangCompilerDes
     return SlangCompiler(std::move(globalSession), paths);
 }
 
-std::expected<CompileResult, Error> SlangCompiler::CompileFromString(
-
-    const std::string& slangCode,
-    const std::string& entryName) {
+std::expected<CompileResult, Error> SlangCompiler::CompileFromString(const std::string& slangCode,
+                                                                     const std::string& entryName) {
     CompilationContext context;
     ComPtr<IBlob> diagnosticBlob;
 
@@ -68,11 +69,60 @@ std::expected<CompileResult, Error> SlangCompiler::CompileFromString(
         return std::unexpected(
             Error{ErrorType::EntryPointNotFound, context.message + errorMessage});
     }
+
     ComPtr<IComponentType> composedProgram;
     {
         IComponentType* componentTypes[] = {module.get(), entry.get()};
         const auto result = session->createCompositeComponentType(
             componentTypes, 2, composedProgram.writeRef(), diagnosticBlob.writeRef());
+
+        if (context.Failed(result, diagnosticBlob.get())) {
+            return std::unexpected(Error{ErrorType::CompilationFailed, context.message});
+        }
+    }
+
+    return CompileInternal(composedProgram.get(), context);
+}
+
+std::expected<CompileResult, Error> SlangCompiler::CompileFromString(const std::string& slangCode) {
+    CompilationContext context;
+    ComPtr<IBlob> diagnosticBlob;
+
+    ComPtr<ISession> session;
+    if (auto result = CreateSession(); result.has_value()) {
+        session = result.value();
+    } else {
+        return std::unexpected(result.error());
+    }
+
+    std::vector<ComPtr<slang::IComponentType>> componentsToLink;
+    ComPtr<IModule> module;
+    {
+        IModule* m = session->loadModuleFromSourceString(
+            "TempModule", "TempModule.slang", slangCode.data(), diagnosticBlob.writeRef());
+        if (m == nullptr) {
+            context.AppendError(diagnosticBlob.get());
+            return std::unexpected(
+                Error{ErrorType::InitFailed, "Failed to load module: " + context.message});
+        }
+        module = m;
+        componentsToLink.push_back(ComPtr<slang::IComponentType>(module.get()));
+    }
+
+    int definedEntryPointCount = module->getDefinedEntryPointCount();
+    for (int i = 0; i < definedEntryPointCount; i++) {
+        ComPtr<slang::IEntryPoint> entryPoint;
+        if (SLANG_FAILED(module->getDefinedEntryPoint(i, entryPoint.writeRef()))) {
+            // TODO!
+        }
+        componentsToLink.push_back(ComPtr<slang::IComponentType>(entryPoint.get()));
+    }
+
+    ComPtr<IComponentType> composedProgram;
+    {
+        const auto result = session->createCompositeComponentType(
+            reinterpret_cast<slang::IComponentType**>(componentsToLink.data()),
+            componentsToLink.size(), composedProgram.writeRef(), diagnosticBlob.writeRef());
 
         if (context.Failed(result, diagnosticBlob.get())) {
             return std::unexpected(Error{ErrorType::CompilationFailed, context.message});
@@ -141,15 +191,25 @@ struct ReflectionContext {
     uint32_t bindingOffset = 0;
     std::string prefix = "";
     sa::ShaderVisibility visibility = sa::ShaderVisibility::None;
+    bool skipResourceDetails = false;
 
     ReflectionContext WithPrefix(const std::string& name) const {
-        return {currentSet, bindingOffset, prefix.empty() ? name : prefix + "." + name, visibility};
+        return {currentSet, bindingOffset, prefix.empty() ? name : prefix + "." + name, visibility,
+                skipResourceDetails};
     }
     ReflectionContext WithSet(uint32_t newSet) const {
-        return {newSet, bindingOffset, prefix, visibility};
+        return {newSet, bindingOffset, prefix, visibility, skipResourceDetails};
     }
     ReflectionContext WithOffset(uint32_t offset) const {
-        return {currentSet, bindingOffset + offset, prefix, visibility};
+        return {currentSet, bindingOffset + offset, prefix, visibility, skipResourceDetails};
+    }
+};
+
+struct VaryingParameterContext {
+    std::string prefix = "";
+
+    VaryingParameterContext WithPrefix(const std::string& name) const {
+        return {prefix.empty() ? name : prefix + "." + name};
     }
 };
 
@@ -161,6 +221,8 @@ struct CompilerBinding {
     sa::ResourceType resourceType;
     sa::ShaderVisibility visibility;
     std::string name;
+
+    slang::ParameterCategory slangCategory;
 };
 
 sa::Texture CreateTextureBinding(VariableLayoutReflection* varLayout,
@@ -245,42 +307,45 @@ sa::Sampler CreateSamplerBinding(VariableLayoutReflection* varLayout,
     return samplerBinding;
 }
 
-std::optional<CompilerBinding> CreateLeafBinding(VariableLayoutReflection* varLayout,
-                                             const ReflectionContext& ctx) {
-    TypeLayoutReflection* typeLayout = varLayout->getTypeLayout();
-    TypeReflection::Kind kind = typeLayout->getKind();
-
-    if (varLayout->getBindingIndex() == -1) {
-        return std::nullopt;
-    }
+CompilerBinding CalculateBasicBinding(VariableLayoutReflection* varLayout,
+                                      const ReflectionContext& ctx,
+                                      slang::TypeReflection::Kind kind) {
+    CompilerBinding binding{};
 
     uint32_t set = ctx.currentSet;
-    if (set == -1) {
+    if (set == static_cast<uint32_t>(-1)) {  // kInvalidSetNumber
         size_t spaceOffset = varLayout->getOffset(slang::ParameterCategory::RegisterSpace);
-        set = (spaceOffset != -SLANG_UNBOUNDED_SIZE) ? (uint32_t)spaceOffset : 0;
+        set = (spaceOffset != -SLANG_UNBOUNDED_SIZE) ? static_cast<uint32_t>(spaceOffset) : 0;
     }
-
-    CompilerBinding binding{};
 
     binding.set = set;
     binding.binding = ctx.bindingOffset + varLayout->getBindingIndex();
     binding.id = core::ToPropertyID(varLayout->getName());
 
-    switch (kind) {
-        case slang::TypeReflection::Kind::ParameterBlock: {
-            size_t cbufferIndex =
-                varLayout->getOffset(slang::ParameterCategory::DescriptorTableSlot);
-            if (cbufferIndex == SLANG_UNBOUNDED_SIZE) {
-                cbufferIndex = 0;
-                break;
-            }
+    if (kind == slang::TypeReflection::Kind::ParameterBlock) {
+        size_t cbufferIndex = varLayout->getOffset(slang::ParameterCategory::DescriptorTableSlot);
+        if (cbufferIndex != SLANG_UNBOUNDED_SIZE) {
             binding.binding = static_cast<uint32_t>(cbufferIndex);
-            [[fallthrough]];
         }
+    }
+    binding.slangCategory = varLayout->getCategory();
+
+    return binding;
+}
+
+bool PopulateResourceDetails(CompilerBinding& binding,
+                             VariableLayoutReflection* varLayout,
+                             const ReflectionContext& ctx,
+                             slang::TypeReflection::Kind kind) {
+    TypeLayoutReflection* typeLayout = varLayout->getTypeLayout();
+
+    switch (kind) {
+        case slang::TypeReflection::Kind::ParameterBlock:
+            [[fallthrough]];
         case slang::TypeReflection::Kind::ConstantBuffer: {
             TypeLayoutReflection* innerType = typeLayout->getElementTypeLayout();
             if (innerType->getSize() == 0) {
-                return std::nullopt;
+                return false;
             }
             binding.resource.buffer.bufferSize = static_cast<uint32_t>(innerType->getSize());
             binding.resourceType = sa::ResourceType::UniformBuffer;
@@ -322,24 +387,63 @@ std::optional<CompilerBinding> CreateLeafBinding(VariableLayoutReflection* varLa
             break;
         default:
             binding.resourceType = sa::ResourceType::Unknown;
-            return std::nullopt;
+            return false;
     }
 
     binding.visibility = ctx.visibility;
     binding.name = ctx.prefix;
+    return true;
+}
+
+std::optional<CompilerBinding> CreateLeafBinding(VariableLayoutReflection* varLayout,
+                                                 const ReflectionContext& ctx) {
+    TypeLayoutReflection* typeLayout = varLayout->getTypeLayout();
+    TypeReflection::Kind kind = typeLayout->getKind();
+
+    if (varLayout->getBindingIndex() == -1) {
+        return std::nullopt;
+    }
+
+    uint32_t set = ctx.currentSet;
+    if (set == -1) {
+        size_t spaceOffset = varLayout->getOffset(slang::ParameterCategory::RegisterSpace);
+        set = (spaceOffset != -SLANG_UNBOUNDED_SIZE) ? (uint32_t)spaceOffset : 0;
+    }
+
+    CompilerBinding binding = CalculateBasicBinding(varLayout, ctx, kind);
+
+    if (kind == slang::TypeReflection::Kind::ParameterBlock) {
+        size_t cbufferIndex = varLayout->getOffset(slang::ParameterCategory::DescriptorTableSlot);
+        if (cbufferIndex != SLANG_UNBOUNDED_SIZE) {
+            binding.binding = static_cast<uint32_t>(cbufferIndex);
+        }
+    }
+
+    if (ctx.skipResourceDetails) {
+        return binding;
+    }
+
+    // 3단계: 세부 리소스 정보 채우기
+    if (!PopulateResourceDetails(binding, varLayout, ctx, kind)) {
+        return std::nullopt;  // 파싱 실패 시
+    }
+
     return binding;
 }
 
 }  // namespace
 std::vector<CompilerBinding> ReflectRecursively(VariableLayoutReflection* varLayout,
-                                            const ReflectionContext& ctx) {
+                                                const ReflectionContext& ctx) {
     std::vector<CompilerBinding> results;
 
     TypeLayoutReflection* typeLayout = varLayout->getTypeLayout();
     TypeReflection::Kind kind = typeLayout->getKind();
 
-    const char* rawName = varLayout->getName();
-    std::string varName = rawName == nullptr ? "" : std::string(rawName);
+    std::string varName = "";
+    if (!ctx.skipResourceDetails) {
+        const char* rawName = varLayout->getName();
+        std::string varName = rawName == nullptr ? "" : std::string(rawName);
+    }
 
     if (kind == TypeReflection::Kind::ParameterBlock) {
         TypeLayoutReflection* innerType = typeLayout->getElementTypeLayout();
@@ -351,15 +455,15 @@ std::vector<CompilerBinding> ReflectRecursively(VariableLayoutReflection* varLay
             newSet = static_cast<uint32_t>(spaceOffset);
         }
 
-        ReflectionContext nexCtx = ctx.WithSet(newSet).WithPrefix(varName);
+        ReflectionContext nextCtx = ctx.WithSet(newSet).WithPrefix(varName);
         uint32_t fieldCount = innerType->getFieldCount();
         for (uint32_t i = 0; i < fieldCount; ++i) {
             VariableLayoutReflection* fieldVar = innerType->getFieldByIndex(i);
-            auto childBindings = ReflectRecursively(fieldVar, nexCtx);
+            auto childBindings = ReflectRecursively(fieldVar, nextCtx);
             results.insert(results.end(), childBindings.begin(), childBindings.end());
         }
 
-        auto childBindings = CreateLeafBinding(varLayout, nexCtx);
+        auto childBindings = CreateLeafBinding(varLayout, nextCtx);
         if (childBindings) {
             results.push_back(childBindings.value());
         }
@@ -372,12 +476,12 @@ std::vector<CompilerBinding> ReflectRecursively(VariableLayoutReflection* varLay
             addedOffset += varLayout->getBindingIndex();
         }
 
-        ReflectionContext nexCtx = ctx.WithPrefix(varName).WithOffset(addedOffset);
+        ReflectionContext nextCtx = ctx.WithPrefix(varName).WithOffset(addedOffset);
 
         uint32_t fieldCount = typeLayout->getFieldCount();
         for (uint32_t i = 0; i < fieldCount; ++i) {
             VariableLayoutReflection* fieldRef = typeLayout->getFieldByIndex(i);
-            auto childBindings = ReflectRecursively(fieldRef, nexCtx);
+            auto childBindings = ReflectRecursively(fieldRef, nextCtx);
             results.insert(results.end(), childBindings.begin(), childBindings.end());
         }
         return results;
@@ -391,6 +495,33 @@ std::vector<CompilerBinding> ReflectRecursively(VariableLayoutReflection* varLay
     return results;
 }
 
+std::vector<CompilerBinding> GenerateBindingsFromEntry(slang::EntryPointReflection* entry,
+                                                       CompilationContext& compilationContext) {
+    std::vector<CompilerBinding> bindings;
+    uint32_t paramCount = entry->getParameterCount();
+    ReflectionContext ctx{
+        .visibility = compilationContext.visibility,
+        .skipResourceDetails = true,
+    };
+    for (uint32_t i = 0; i < paramCount; ++i) {
+        VariableLayoutReflection* varRefl = entry->getParameterByIndex(i);
+        std::string empty("");
+        // Search recursively binding info from slang reflection tree and store in the binsings.
+        size_t spaceOffset = varRefl->getBindingSpace();
+        const std::vector<CompilerBinding> result =
+            ReflectRecursively(varRefl, ctx.WithSet(spaceOffset));
+        bindings.insert(bindings.end(), result.begin(), result.end());
+    }
+
+    std::ranges::sort(bindings, [](CompilerBinding& a, CompilerBinding& b) -> bool {
+        if (a.set != b.set) {
+            return a.set < b.set;
+        }
+        return a.binding < b.binding;
+    });
+
+    return bindings;
+}
 std::vector<CompilerBinding> GenerateBindingsFromLayout(slang::ProgramLayout* layout,
                                                         CompilationContext& compilationContext) {
     std::vector<CompilerBinding> bindings;
@@ -430,6 +561,116 @@ static sa::ShaderVisibility GetVisibility(SlangStage stage) {
             return sa::ShaderVisibility::None;
     }
 }
+namespace {
+struct CompilerVariable {
+    sa::Kind kind;
+    sa::ScalarType scalarType;
+    sa::Shape shape;
+    std::string name;
+};
+struct CompilerShaderParameter {
+    CompilerVariable variable;
+    uint32_t location;
+    std::optional<std::string> semanticName;
+};
+struct CompilerEntryParameter {
+    std::vector<CompilerShaderParameter> input;
+    std::vector<CompilerShaderParameter> output;
+};
+}  // namespace
+
+std::vector<CompilerShaderParameter> CreateVaryingParameterLayout(
+    slang::VariableLayoutReflection* varLayout,
+    const VaryingParameterContext& context) {
+    slang::TypeLayoutReflection* typeLayout = varLayout->getTypeLayout();
+    std::vector<CompilerShaderParameter> shaderParameters;
+    CompilerVariable variable{};
+    switch (typeLayout->getKind()) {
+        case slang::TypeReflection::Kind::Scalar: {
+            variable.kind = sa::Kind::Scalar;
+            variable.shape = sa::Shape::Scalar();
+            break;
+        }
+        case slang::TypeReflection::Kind::Vector: {
+            variable.kind = sa::Kind::Vector;
+            variable.shape = sa::Shape::Vector(typeLayout->getElementCount());
+            break;
+        }
+        case slang::TypeReflection::Kind::Matrix: {
+            variable.kind = sa::Kind::Matrix;
+            variable.shape =
+                sa::Shape::Matrix(typeLayout->getColumnCount(), typeLayout->getRowCount());
+            break;
+        }
+        case slang::TypeReflection::Kind::Struct: {
+            uint32_t fieldCount = typeLayout->getFieldCount();
+            for (uint32_t i = 0; i < fieldCount; ++i) {
+                auto* param = typeLayout->getFieldByIndex(i);
+                const VaryingParameterContext nextCtx = context.WithPrefix(param->getName());
+                std::vector<CompilerShaderParameter> fields =
+                    CreateVaryingParameterLayout(param, nextCtx);
+                shaderParameters.append_range(fields);
+                continue;
+            }
+            return shaderParameters;
+        }
+        default:
+            break;
+    }
+    slang::TypeReflection::ScalarType scalarType = typeLayout->getScalarType();
+    switch (scalarType) {
+        case slang::TypeReflection::ScalarType::Float16:
+            variable.scalarType = sa::ScalarType::F16;
+            break;
+        case slang::TypeReflection::ScalarType::Float32:
+            variable.scalarType = sa::ScalarType::F32;
+            break;
+        case slang::TypeReflection::ScalarType::UInt32:
+            variable.scalarType = sa::ScalarType::U32;
+            break;
+        case slang::TypeReflection::ScalarType::Int32:
+            variable.scalarType = sa::ScalarType::I32;
+            break;
+        case slang::TypeReflection::ScalarType::Bool:
+            variable.scalarType = sa::ScalarType::Bool;
+            break;
+        case slang::TypeReflection::ScalarType::Int16:
+        case slang::TypeReflection::ScalarType::Int64:
+        case slang::TypeReflection::ScalarType::UInt16:
+        case slang::TypeReflection::ScalarType::UInt64:
+        case slang::TypeReflection::ScalarType::Float64:
+        default:
+            break;
+    }
+
+    variable.name = context.prefix;
+
+    const char* semanticName = varLayout->getSemanticName();
+    const uint32_t location = varLayout->getOffset(slang::ParameterCategory::VaryingInput);
+    // const uint32_t location = varLayout->getBindingIndex();
+    shaderParameters.push_back(CompilerShaderParameter{
+        .variable = variable,
+        .location = location,
+        .semanticName = semanticName == nullptr ? std::nullopt : std::make_optional(semanticName),
+    });
+    return shaderParameters;
+}
+
+CompilerEntryParameter GernerateEntryPointLayout(slang::EntryPointReflection* layout,
+                                                 CompilationContext& context) {
+    VaryingParameterContext varyingContext;
+    slang::VariableLayoutReflection* paramaterVarLayout = layout->getVarLayout();
+    std::vector<CompilerShaderParameter> entryInputParameters =
+        CreateVaryingParameterLayout(paramaterVarLayout, varyingContext);
+    slang::VariableLayoutReflection* resultVarLayout = layout->getResultVarLayout();
+    // const uint32_t resultVarCount
+    std::vector<CompilerShaderParameter> entryOutpuParameters =
+        CreateVaryingParameterLayout(resultVarLayout, varyingContext);
+    return {
+        entryInputParameters,
+        entryOutpuParameters,
+    };
+}
 
 std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInternal(
     slang::IComponentType* composedProgram,
@@ -454,48 +695,123 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
         }
     }
 
+    std::vector<std::string> nameTable;
+    std::unordered_map<std::string, uint32_t> stringPool;
+    const auto getNameId = [&](const std::string& name) {
+        const auto [it, inserted] = stringPool.try_emplace(name, nameTable.size());
+        if (inserted) {
+            nameTable.push_back(name);
+        }
+        return it->second;
+    };
+
+    std::vector<sa::ShaderParameter> parameters;
+    const auto attachParameter = [&](const CompilerShaderParameter& cp) {
+        const auto& variable = cp.variable;
+        sa::ShaderParameter parameter{
+            .variable =
+                sa::Variable{
+                    .kind = variable.kind,
+                    .scalarType = variable.scalarType,
+                    .shape = variable.shape,
+                    .nameIdx = getNameId(variable.name),
+                },
+            .location = cp.location,
+            .semanticNameIdx =
+                cp.semanticName.has_value() ? getNameId(cp.semanticName.value()) : sa::kInvalidIdx,
+        };
+
+        const auto it = std::ranges::find(parameters, parameter);
+        if (it == parameters.end()) {
+            parameters.push_back(parameter);
+            return parameters.size() - 1;
+        } else {
+            return static_cast<std::size_t>(std::distance(parameters.begin(), it));
+        }
+    };
+
     ProgramLayout* programLayout = linkedProgram->getLayout();
-    sa::ShaderVisibility visibility = sa::ShaderVisibility::None;
-    if (programLayout->getEntryPointCount() > 0) {
-        visibility = GetVisibility(programLayout->getEntryPointByIndex(0)->getStage());
-    }
-    context.visibility = visibility;
     std::vector<CompilerBinding> compilerBindings =
         GenerateBindingsFromLayout(programLayout, context);
-
-    std::vector<std::string> nameTable;
-    std::vector<sa::Binding> bindings;
-    {
-        std::unordered_map<std::string, uint32_t> tempNameMap;
-        bindings.reserve(compilerBindings.size());
-        for (uint32_t i = 0; i < compilerBindings.size(); ++i) {
-            const auto& cb = compilerBindings[i];
-            const auto [it, inserted] = tempNameMap.try_emplace(cb.name, nameTable.size());
-            if (inserted) {
-                nameTable.push_back(cb.name);
-            }
-            bindings.push_back(sa::Binding{
+    std::vector<sa::Binding> bindings =
+        compilerBindings | std::views::transform([&](CompilerBinding& cb) -> sa::Binding {
+            return sa::Binding{
                 .set = cb.set,
                 .binding = cb.binding,
                 .id = cb.id,
-                .nameIdx = it->second,
+                .nameIdx = getNameId(cb.name),
                 .resource = cb.resource,
                 .resourceType = cb.resourceType,
                 .visibility = cb.visibility,
-            });
+            };
+        }) |
+        std::ranges::to<std::vector>();
+
+    uint32_t entryCount = programLayout->getEntryPointCount();
+    std::vector<uint32_t> indices;
+    std::vector<sa::EntryPoint> entryPoints;
+    for (uint32_t i = 0; i < entryCount; ++i) {
+        slang::EntryPointReflection* entry = programLayout->getEntryPointByIndex(i);
+        sa::ShaderVisibility visibility = GetVisibility(entry->getStage());
+        context.visibility = visibility;
+        CompilerEntryParameter compilerParameters = GernerateEntryPointLayout(entry, context);
+        sa::EntryPoint entryPoint;
+
+        entryPoint.stage = context.visibility;
+        if ((entryPoint.stage & sa::ShaderVisibility::Vertex) == sa::ShaderVisibility::Vertex) {
+            entryPoint.ioStartIndex = indices.size();
+            entryPoint.ioCount = compilerParameters.input.size();
+            for (uint32_t i = 0; i < compilerParameters.input.size(); ++i) {
+                uint32_t idx = attachParameter(compilerParameters.input[i]);
+                indices.push_back(idx);
+            }
         }
+        if ((entryPoint.stage & sa::ShaderVisibility::Fragment) == sa::ShaderVisibility::Fragment) {
+            entryPoint.ioStartIndex = indices.size();
+            entryPoint.ioCount = compilerParameters.output.size();
+            for (uint32_t i = 0; i < compilerParameters.output.size(); ++i) {
+                uint32_t idx = attachParameter(compilerParameters.output[i]);
+                indices.push_back(idx);
+            }
+        }
+
+        entryPoint.bindingStartIndex = indices.size();
+        entryPoint.bindingCount = 0;
+        ComPtr<IMetadata> metadata;
+        composedProgram->getEntryPointMetadata(i, 0, metadata.writeRef());
+        for (uint32_t j = 0; j < compilerBindings.size(); ++j) {
+            const auto& b = compilerBindings[j];
+            bool isUsed = false;
+
+            // b.category는 SlangParameterCategory::DescriptorTableSlot 등을 매핑해야 합니다.
+            metadata->isParameterLocationUsed(static_cast<SlangParameterCategory>(b.slangCategory),
+                                              b.set, b.binding, isUsed);
+
+            if (isUsed) {
+                entryPoint.bindingCount++;  // 실제로 쓰는 것만 저장!
+                indices.push_back(j);       // 실제로 쓰는 것만 저장!
+            }
+        }
+        uint32_t nameIdx = getNameId(entry->getName());
+        entryPoint.nameIdx = nameIdx;
+
+        entryPoints.push_back(entryPoint);
     }
 
+    uint32_t nameTableSize = std::ranges::fold_left(
+        nameTable, 0u, [](uint32_t acc, const std::string& name) { return acc + name.size() + 1; });
+
     std::vector<uint8_t> code(codeBlob->getBufferSize());
-    memcpy(code.data(), codeBlob->getBufferPointer(), codeBlob->getBufferSize());
-    sa::Header header = {
-        .bindingCount = static_cast<uint16_t>(bindings.size()),
-        .shaderSize = static_cast<uint32_t>(code.size()),
-        .entryShaderStage = visibility,
-    };
+    std::memcpy(code.data(), codeBlob->getBufferPointer(), codeBlob->getBufferSize());
+
     // temp return
-    return std::expected<CompileResult, Error>(CompileResult{
-        .header = header, .bindings = bindings, .sourceBlob = code, .warning = context.message});
+    return std::expected<CompileResult, Error>(CompileResult{.parameters = std::move(parameters),
+                                                             .bindings = std::move(bindings),
+                                                             .entryPoints = std::move(entryPoints),
+                                                             .sourceBlob = std::move(code),
+                                                             .nameTable = std::move(nameTable),
+                                                             .indices = std::move(indices),
+                                                             .warning = context.message});
 }
 
 std::expected<Slang::ComPtr<slang::ISession>, Error> SlangCompiler::CreateSession() {

--- a/shader/SlangCompiler.cpp
+++ b/shader/SlangCompiler.cpp
@@ -153,6 +153,16 @@ struct ReflectionContext {
     }
 };
 
+struct CompilerBinding {
+    uint32_t set;
+    uint32_t binding;
+    uint32_t id;
+    sa::Resource resource = {.buffer = {0}};
+    sa::ResourceType resourceType;
+    sa::ShaderVisibility visibility;
+    std::string name;
+};
+
 sa::Texture CreateTextureBinding(VariableLayoutReflection* varLayout,
                                  const ReflectionContext& ctx) {
     slang::TypeLayoutReflection* typeLayout = varLayout->getTypeLayout();
@@ -235,7 +245,7 @@ sa::Sampler CreateSamplerBinding(VariableLayoutReflection* varLayout,
     return samplerBinding;
 }
 
-std::optional<sa::Binding> CreateLeafBinding(VariableLayoutReflection* varLayout,
+std::optional<CompilerBinding> CreateLeafBinding(VariableLayoutReflection* varLayout,
                                              const ReflectionContext& ctx) {
     TypeLayoutReflection* typeLayout = varLayout->getTypeLayout();
     TypeReflection::Kind kind = typeLayout->getKind();
@@ -250,7 +260,7 @@ std::optional<sa::Binding> CreateLeafBinding(VariableLayoutReflection* varLayout
         set = (spaceOffset != -SLANG_UNBOUNDED_SIZE) ? (uint32_t)spaceOffset : 0;
     }
 
-    sa::Binding binding{};
+    CompilerBinding binding{};
 
     binding.set = set;
     binding.binding = ctx.bindingOffset + varLayout->getBindingIndex();
@@ -316,19 +326,14 @@ std::optional<sa::Binding> CreateLeafBinding(VariableLayoutReflection* varLayout
     }
 
     binding.visibility = ctx.visibility;
-    if (!ctx.prefix.empty()) {
-        std::string_view nameView = ctx.prefix;
-        size_t copyLen = std::min(nameView.size(), sizeof(binding.name) - 1);
-        std::memcpy(binding.name, nameView.data(), copyLen);
-        binding.name[copyLen] = '\0';
-    }
+    binding.name = ctx.prefix;
     return binding;
 }
 
 }  // namespace
-std::vector<sa::Binding> ReflectRecursively(VariableLayoutReflection* varLayout,
+std::vector<CompilerBinding> ReflectRecursively(VariableLayoutReflection* varLayout,
                                             const ReflectionContext& ctx) {
-    std::vector<sa::Binding> results;
+    std::vector<CompilerBinding> results;
 
     TypeLayoutReflection* typeLayout = varLayout->getTypeLayout();
     TypeReflection::Kind kind = typeLayout->getKind();
@@ -386,23 +391,24 @@ std::vector<sa::Binding> ReflectRecursively(VariableLayoutReflection* varLayout,
     return results;
 }
 
-std::vector<sa::Binding> GenerateBindingsFromLayout(slang::ProgramLayout* layout,
-                                                    sa::ShaderVisibility visibility) {
-    std::vector<sa::Binding> bindings;
+std::vector<CompilerBinding> GenerateBindingsFromLayout(slang::ProgramLayout* layout,
+                                                        CompilationContext& compilationContext) {
+    std::vector<CompilerBinding> bindings;
     uint32_t paramCount = layout->getParameterCount();
     ReflectionContext ctx{
-        .visibility = visibility,
+        .visibility = compilationContext.visibility,
     };
     for (uint32_t i = 0; i < paramCount; ++i) {
         VariableLayoutReflection* varRefl = layout->getParameterByIndex(i);
         std::string empty("");
         // Search recursively binding info from slang reflection tree and store in the binsings.
         size_t spaceOffset = varRefl->getBindingSpace();
-        auto result = ReflectRecursively(varRefl, ctx.WithSet(spaceOffset));
+        const std::vector<CompilerBinding> result =
+            ReflectRecursively(varRefl, ctx.WithSet(spaceOffset));
         bindings.insert(bindings.end(), result.begin(), result.end());
     }
 
-    std::ranges::sort(bindings, [](sa::Binding& a, sa::Binding& b) -> bool {
+    std::ranges::sort(bindings, [](CompilerBinding& a, CompilerBinding& b) -> bool {
         if (a.set != b.set) {
             return a.set < b.set;
         }
@@ -448,13 +454,37 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
         }
     }
 
-    ProgramLayout* layout = linkedProgram->getLayout();
+    ProgramLayout* programLayout = linkedProgram->getLayout();
     sa::ShaderVisibility visibility = sa::ShaderVisibility::None;
-    if (layout->getEntryPointCount() > 0) {
-        visibility = GetVisibility(layout->getEntryPointByIndex(0)->getStage());
+    if (programLayout->getEntryPointCount() > 0) {
+        visibility = GetVisibility(programLayout->getEntryPointByIndex(0)->getStage());
     }
+    context.visibility = visibility;
+    std::vector<CompilerBinding> compilerBindings =
+        GenerateBindingsFromLayout(programLayout, context);
 
-    std::vector<sa::Binding> bindings = GenerateBindingsFromLayout(layout, visibility);
+    std::vector<std::string> nameTable;
+    std::vector<sa::Binding> bindings;
+    {
+        std::unordered_map<std::string, uint32_t> tempNameMap;
+        bindings.reserve(compilerBindings.size());
+        for (uint32_t i = 0; i < compilerBindings.size(); ++i) {
+            const auto& cb = compilerBindings[i];
+            const auto [it, inserted] = tempNameMap.try_emplace(cb.name, nameTable.size());
+            if (inserted) {
+                nameTable.push_back(cb.name);
+            }
+            bindings.push_back(sa::Binding{
+                .set = cb.set,
+                .binding = cb.binding,
+                .id = cb.id,
+                .nameIdx = it->second,
+                .resource = cb.resource,
+                .resourceType = cb.resourceType,
+                .visibility = cb.visibility,
+            });
+        }
+    }
 
     std::vector<uint8_t> code(codeBlob->getBufferSize());
     memcpy(code.data(), codeBlob->getBufferPointer(), codeBlob->getBufferSize());

--- a/shader/SlangCompiler.cpp
+++ b/shader/SlangCompiler.cpp
@@ -385,6 +385,19 @@ CompilerBinding CalculateBasicBinding(VariableLayoutReflection* varLayout,
     return binding;
 }
 
+static sa::ShaderVisibility GetVisibility(SlangStage stage) {
+    switch (stage) {
+        case SLANG_STAGE_VERTEX:
+            return sa::ShaderVisibility::Vertex;
+        case SLANG_STAGE_FRAGMENT:
+            return sa::ShaderVisibility::Fragment;
+        case SLANG_STAGE_COMPUTE:
+            return sa::ShaderVisibility::Compute;
+        default:
+            return sa::ShaderVisibility::None;
+    }
+}
+
 bool PopulateResourceDetails(CompilerBinding& binding,
                              VariableLayoutReflection* varLayout,
                              const ReflectionContext& ctx,
@@ -441,7 +454,6 @@ bool PopulateResourceDetails(CompilerBinding& binding,
             binding.resourceType = sa::ResourceType::Unknown;
             return false;
     }
-
     binding.visibility = ctx.visibility;
     binding.name = ctx.prefix;
     return true;
@@ -476,7 +488,7 @@ std::optional<CompilerBinding> CreateLeafBinding(VariableLayoutReflection* varLa
     }
 
     if (!PopulateResourceDetails(binding, varLayout, ctx, kind)) {
-        return std::nullopt;  
+        return std::nullopt; 
     }
 
     return binding;
@@ -573,18 +585,6 @@ std::vector<CompilerBinding> GenerateBindingsFromLayout(slang::ProgramLayout* la
     return bindings;
 }
 
-static sa::ShaderVisibility GetVisibility(SlangStage stage) {
-    switch (stage) {
-        case SLANG_STAGE_VERTEX:
-            return sa::ShaderVisibility::Vertex;
-        case SLANG_STAGE_FRAGMENT:
-            return sa::ShaderVisibility::Fragment;
-        case SLANG_STAGE_COMPUTE:
-            return sa::ShaderVisibility::Compute;
-        default:
-            return sa::ShaderVisibility::None;
-    }
-}
 namespace {
 struct CompilerVariable {
     sa::Kind kind;
@@ -596,6 +596,7 @@ struct CompilerShaderParameter {
     CompilerVariable variable;
     uint32_t location;
     std::optional<std::string> semanticName;
+    uint8_t semanticIndex;
 };
 struct CompilerEntryParameter {
     std::vector<CompilerShaderParameter> input;
@@ -675,7 +676,9 @@ std::vector<CompilerShaderParameter> CreateVaryingParameterLayout(
     shaderParameters.push_back(CompilerShaderParameter{
         .variable = variable,
         .location = location,
-        .semanticName = semanticName == nullptr ? std::nullopt : std::make_optional(semanticName),
+        .semanticName =
+            semanticName == nullptr ? std::nullopt : std::make_optional(std::string(semanticName)),
+        .semanticIndex = static_cast<uint8_t>(varLayout->getSemanticIndex()),
     });
     return shaderParameters;
 }
@@ -741,8 +744,9 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
                     .nameIdx = getNameId(variable.name),
                 },
             .location = cp.location,
-            .semanticNameIdx =
-                cp.semanticName.has_value() ? getNameId(cp.semanticName.value()) : sa::kInvalidIdx,
+            .semantic = cp.semanticName.has_value()
+                            ? core::NameToSemantic(cp.semanticName.value(), cp.semanticIndex)
+                            : core::Semantic::Undefined,
         };
 
         const auto it = std::ranges::find(parameters, parameter);
@@ -853,12 +857,9 @@ std::expected<Slang::ComPtr<slang::ISession>, Error> SlangCompiler::CreateSessio
             std::println(" - \"{}\"", path);
         }
         std::vector<CompilerOptionEntry> options;
-        options.emplace_back(
-            slang::CompilerOptionEntry{.name = slang::CompilerOptionName::MatrixLayoutColumn,
-                                       .value = {
-                                           .kind = slang::CompilerOptionValueKind::Int,
-                                           .intValue0 = 1 
-                                       }});
+        options.emplace_back(slang::CompilerOptionEntry{
+            .name = slang::CompilerOptionName::MatrixLayoutColumn,
+            .value = {.kind = slang::CompilerOptionValueKind::Int, .intValue0 = 1}});
         const SessionDesc sessionDesc{
             .targets = &targetDesc,
             .targetCount = 1,

--- a/shader/SlangCompiler.cpp
+++ b/shader/SlangCompiler.cpp
@@ -180,6 +180,59 @@ std::expected<CompileResult, Error> SlangCompiler::Compile(const std::string& pa
     return CompileInternal(composedProgram.get(), context);
 }
 
+std::expected<CompileResult, Error> SlangCompiler::Compile(const std::string& path) {
+    CompilationContext context;
+
+    ComPtr<ISession> session;
+    if (auto result = CreateSession(); result.has_value()) {
+        session = result.value();
+    } else {
+        return std::unexpected(result.error());
+    }
+
+    std::vector<ComPtr<slang::IComponentType>> componentsToLink;
+    ComPtr<IModule> module;
+    ComPtr<IBlob> diagnosticBlob;
+    {
+        if (!std::filesystem::exists(path)) {
+            return std::unexpected(
+                Error{ErrorType::IOError, "Failed to find filepath: \"" + path + "\"!\n"});
+        }
+        IModule* m = session->loadModule(path.data(), diagnosticBlob.writeRef());
+        if (m == nullptr) {
+            context.AppendError(diagnosticBlob.get());
+            return std::unexpected(
+                Error{ErrorType::InitFailed, "Failed to load module: " + context.message});
+        }
+        module = m;
+        componentsToLink.push_back(ComPtr<slang::IComponentType>(module.get()));
+    }
+
+    int definedEntryPointCount = module->getDefinedEntryPointCount();
+    for (int i = 0; i < definedEntryPointCount; i++) {
+        ComPtr<slang::IEntryPoint> entryPoint;
+        if (SLANG_FAILED(module->getDefinedEntryPoint(i, entryPoint.writeRef()))) {
+            std::string errorMessage = "Error: Entry(" + std::to_string(i) + ") was not found!\n";
+            return std::unexpected(
+                Error{ErrorType::EntryPointNotFound, context.message + errorMessage});
+        }
+        componentsToLink.push_back(ComPtr<slang::IComponentType>(entryPoint.get()));
+    }
+
+    ComPtr<IComponentType> composedProgram;
+    {
+        const auto result = session->createCompositeComponentType(
+            reinterpret_cast<slang::IComponentType**>(componentsToLink.data()),
+            componentsToLink.size(), composedProgram.writeRef(), diagnosticBlob.writeRef());
+
+        if (context.Failed(result, diagnosticBlob.get())) {
+            return std::unexpected(Error{ErrorType::CompilationFailed, context.message});
+        }
+    }
+
+    return CompileInternal(composedProgram.get(), context);
+}
+
 constexpr uint32_t kInvalidSetNumber = -1;
 inline bool IsValidSet(uint32_t setNumber) {
     return setNumber != kInvalidSetNumber;
@@ -660,7 +713,7 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
     ComPtr<IBlob> codeBlob;
     {
         const auto result =
-            linkedProgram->getEntryPointCode(0, 0, codeBlob.writeRef(), diagnosticBlob.writeRef());
+            linkedProgram->getTargetCode(0, codeBlob.writeRef(), diagnosticBlob.writeRef());
         if (context.Failed(result, diagnosticBlob.get())) {
             return std::unexpected(Error{ErrorType::CompilationFailed, context.message});
         }

--- a/shader/SlangCompiler.cpp
+++ b/shader/SlangCompiler.cpp
@@ -749,13 +749,7 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
                             : core::Semantic::Undefined,
         };
 
-        const auto it = std::ranges::find(parameters, parameter);
-        if (it == parameters.end()) {
-            parameters.push_back(parameter);
-            return parameters.size() - 1;
-        } else {
-            return static_cast<std::size_t>(std::distance(parameters.begin(), it));
-        }
+         parameters.push_back(parameter);
     };
 
     ProgramLayout* programLayout = linkedProgram->getLayout();
@@ -774,19 +768,17 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
 
         entryPoint.stage = context.visibility;
         if ((entryPoint.stage & sa::ShaderVisibility::Vertex) == sa::ShaderVisibility::Vertex) {
-            entryPoint.ioStartIndex = indices.size();
+            entryPoint.ioStartIndex = parameters.size();
             entryPoint.ioCount = compilerParameters.input.size();
             for (uint32_t i = 0; i < compilerParameters.input.size(); ++i) {
-                uint32_t idx = attachParameter(compilerParameters.input[i]);
-                indices.push_back(idx);
+                attachParameter(compilerParameters.input[i]);
             }
         }
         if ((entryPoint.stage & sa::ShaderVisibility::Fragment) == sa::ShaderVisibility::Fragment) {
-            entryPoint.ioStartIndex = indices.size();
+            entryPoint.ioStartIndex = parameters.size();
             entryPoint.ioCount = compilerParameters.output.size();
             for (uint32_t i = 0; i < compilerParameters.output.size(); ++i) {
-                uint32_t idx = attachParameter(compilerParameters.output[i]);
-                indices.push_back(idx);
+                attachParameter(compilerParameters.output[i]);
             }
         }
 

--- a/shader/SlangCompiler.cpp
+++ b/shader/SlangCompiler.cpp
@@ -301,8 +301,7 @@ sa::Texture CreateTextureBinding(VariableLayoutReflection* varLayout,
 sa::Sampler CreateSamplerBinding(VariableLayoutReflection* varLayout,
                                  const ReflectionContext& ctx) {
     sa::Sampler samplerBinding{};
-    // Slang의 SamplerState는 Filtering, NonFiltering, Comparison 등의 세부 타입을 가질 수 있음
-    // 여기서는 단순히 Filtering 타입으로 매핑
+
     samplerBinding.type = sa::ShaderAssetFormat::SamplerType::Filtering;
     return samplerBinding;
 }
@@ -423,9 +422,8 @@ std::optional<CompilerBinding> CreateLeafBinding(VariableLayoutReflection* varLa
         return binding;
     }
 
-    // 3단계: 세부 리소스 정보 채우기
     if (!PopulateResourceDetails(binding, varLayout, ctx, kind)) {
-        return std::nullopt;  // 파싱 실패 시
+        return std::nullopt;  
     }
 
     return binding;
@@ -495,33 +493,6 @@ std::vector<CompilerBinding> ReflectRecursively(VariableLayoutReflection* varLay
     return results;
 }
 
-std::vector<CompilerBinding> GenerateBindingsFromEntry(slang::EntryPointReflection* entry,
-                                                       CompilationContext& compilationContext) {
-    std::vector<CompilerBinding> bindings;
-    uint32_t paramCount = entry->getParameterCount();
-    ReflectionContext ctx{
-        .visibility = compilationContext.visibility,
-        .skipResourceDetails = true,
-    };
-    for (uint32_t i = 0; i < paramCount; ++i) {
-        VariableLayoutReflection* varRefl = entry->getParameterByIndex(i);
-        std::string empty("");
-        // Search recursively binding info from slang reflection tree and store in the binsings.
-        size_t spaceOffset = varRefl->getBindingSpace();
-        const std::vector<CompilerBinding> result =
-            ReflectRecursively(varRefl, ctx.WithSet(spaceOffset));
-        bindings.insert(bindings.end(), result.begin(), result.end());
-    }
-
-    std::ranges::sort(bindings, [](CompilerBinding& a, CompilerBinding& b) -> bool {
-        if (a.set != b.set) {
-            return a.set < b.set;
-        }
-        return a.binding < b.binding;
-    });
-
-    return bindings;
-}
 std::vector<CompilerBinding> GenerateBindingsFromLayout(slang::ProgramLayout* layout,
                                                         CompilationContext& compilationContext) {
     std::vector<CompilerBinding> bindings;
@@ -733,19 +704,6 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
     ProgramLayout* programLayout = linkedProgram->getLayout();
     std::vector<CompilerBinding> compilerBindings =
         GenerateBindingsFromLayout(programLayout, context);
-    std::vector<sa::Binding> bindings =
-        compilerBindings | std::views::transform([&](CompilerBinding& cb) -> sa::Binding {
-            return sa::Binding{
-                .set = cb.set,
-                .binding = cb.binding,
-                .id = cb.id,
-                .nameIdx = getNameId(cb.name),
-                .resource = cb.resource,
-                .resourceType = cb.resourceType,
-                .visibility = cb.visibility,
-            };
-        }) |
-        std::ranges::to<std::vector>();
 
     uint32_t entryCount = programLayout->getEntryPointCount();
     std::vector<uint32_t> indices;
@@ -783,13 +741,13 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
             const auto& b = compilerBindings[j];
             bool isUsed = false;
 
-            // b.category는 SlangParameterCategory::DescriptorTableSlot 등을 매핑해야 합니다.
             metadata->isParameterLocationUsed(static_cast<SlangParameterCategory>(b.slangCategory),
                                               b.set, b.binding, isUsed);
 
             if (isUsed) {
-                entryPoint.bindingCount++;  // 실제로 쓰는 것만 저장!
-                indices.push_back(j);       // 실제로 쓰는 것만 저장!
+                entryPoint.bindingCount++;
+                indices.push_back(j);
+                compilerBindings[j].visibility = compilerBindings[j].visibility | entryPoint.stage;
             }
         }
         uint32_t nameIdx = getNameId(entry->getName());
@@ -797,6 +755,20 @@ std::expected<CompileResult, Error> slangCompiler::SlangCompiler::CompileInterna
 
         entryPoints.push_back(entryPoint);
     }
+
+    std::vector<sa::Binding> bindings =
+        compilerBindings | std::views::transform([&](CompilerBinding& cb) -> sa::Binding {
+            return sa::Binding{
+                .set = cb.set,
+                .binding = cb.binding,
+                .id = cb.id,
+                .nameIdx = getNameId(cb.name),
+                .resource = cb.resource,
+                .resourceType = cb.resourceType,
+                .visibility = cb.visibility,
+            };
+        }) |
+        std::ranges::to<std::vector>();
 
     uint32_t nameTableSize = std::ranges::fold_left(
         nameTable, 0u, [](uint32_t acc, const std::string& name) { return acc + name.size() + 1; });
@@ -832,7 +804,7 @@ std::expected<Slang::ComPtr<slang::ISession>, Error> SlangCompiler::CreateSessio
             slang::CompilerOptionEntry{.name = slang::CompilerOptionName::MatrixLayoutColumn,
                                        .value = {
                                            .kind = slang::CompilerOptionValueKind::Int,
-                                           .intValue0 = 1  // 여기서 Column-Major 설정
+                                           .intValue0 = 1 
                                        }});
         const SessionDesc sessionDesc{
             .targets = &targetDesc,

--- a/shader/SlangCompiler.h
+++ b/shader/SlangCompiler.h
@@ -29,12 +29,13 @@ struct Error {
 };
 
 struct CompileResult {
-    core::ShaderAssetFormat::Header header;
     std::vector<core::ShaderAssetFormat::ShaderParameter> parameters;
     std::vector<core::ShaderAssetFormat::Binding> bindings;
     std::vector<core::ShaderAssetFormat::Variable> variables;
+    std::vector<core::ShaderAssetFormat::EntryPoint> entryPoints;
     std::vector<uint8_t> sourceBlob;
     std::vector<std::string> nameTable;
+    std::vector<uint32_t> indices;
     std::string warning;
 };
 
@@ -42,7 +43,9 @@ struct CompilationContext {
     std::string message;
     core::ShaderAssetFormat::ShaderVisibility visibility =
         core::ShaderAssetFormat::ShaderVisibility::None;
-    std::vector<std::string> nameTable;
+
+    slang::IModule* module;
+    std::vector<slang::IEntryPoint*> entryPoints;
 
     bool Failed(SlangResult result, slang::IBlob* diagnosticBlob);
 
@@ -58,6 +61,7 @@ class SlangCompiler {
     static std::expected<SlangCompiler, Error> Create(const SlangCompilerDesc& desc);
     std::expected<CompileResult, Error> CompileFromString(const std::string& slangCode,
                                                           const std::string& entryName);
+    std::expected<CompileResult, Error> CompileFromString(const std::string& slangCode);
     std::expected<CompileResult, Error> Compile(const std::string& path,
                                                 const std::string& entryName);
 

--- a/shader/SlangCompiler.h
+++ b/shader/SlangCompiler.h
@@ -15,12 +15,12 @@ namespace slangCompiler {
 
 enum class ErrorType {
     None = 0,
-    InitFailed,          // Slang 세션 초기화 실패 (DLL 누락 등)
-    IOError,             // 파일 읽기 실패
-    CompilationFailed,   // 셰이더 문법 오류, 링크 오류
-    EntryPointNotFound,  // "main" 함수를 못 찾음
-    ReflectionFailed,    // 리플렉션 데이터 추출 실패 (지원하지 않는 타입 등)
-    InternalError,       // 기타 메모리 부족 등
+    InitFailed,
+    IOError,
+    CompilationFailed,
+    EntryPointNotFound,
+    ReflectionFailed,
+    InternalError,
 };
 
 struct Error {

--- a/shader/SlangCompiler.h
+++ b/shader/SlangCompiler.h
@@ -64,6 +64,7 @@ class SlangCompiler {
     std::expected<CompileResult, Error> CompileFromString(const std::string& slangCode);
     std::expected<CompileResult, Error> Compile(const std::string& path,
                                                 const std::string& entryName);
+    std::expected<CompileResult, Error> Compile(const std::string& path);
 
   private:
     SlangCompiler(Slang::ComPtr<slang::IGlobalSession> globalSession,

--- a/shader/SlangCompiler.h
+++ b/shader/SlangCompiler.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <vector>
 #include <expected>
-#include <string>
-#include <functional>
 #include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
 
 #include <ShaderAssetFormat.h>
 #include <slang-com-ptr.h>
@@ -20,7 +20,7 @@ enum class ErrorType {
     CompilationFailed,   // 셰이더 문법 오류, 링크 오류
     EntryPointNotFound,  // "main" 함수를 못 찾음
     ReflectionFailed,    // 리플렉션 데이터 추출 실패 (지원하지 않는 타입 등)
-    InternalError    ,    // 기타 메모리 부족 등
+    InternalError,       // 기타 메모리 부족 등
 };
 
 struct Error {
@@ -30,13 +30,19 @@ struct Error {
 
 struct CompileResult {
     core::ShaderAssetFormat::Header header;
+    std::vector<core::ShaderAssetFormat::ShaderParameter> parameters;
     std::vector<core::ShaderAssetFormat::Binding> bindings;
+    std::vector<core::ShaderAssetFormat::Variable> variables;
     std::vector<uint8_t> sourceBlob;
+    std::vector<std::string> nameTable;
     std::string warning;
 };
 
 struct CompilationContext {
     std::string message;
+    core::ShaderAssetFormat::ShaderVisibility visibility =
+        core::ShaderAssetFormat::ShaderVisibility::None;
+    std::vector<std::string> nameTable;
 
     bool Failed(SlangResult result, slang::IBlob* diagnosticBlob);
 
@@ -49,15 +55,17 @@ struct SlangCompilerDesc {
 
 class SlangCompiler {
   public:
-
     static std::expected<SlangCompiler, Error> Create(const SlangCompilerDesc& desc);
     std::expected<CompileResult, Error> CompileFromString(const std::string& slangCode,
-                                                           const std::string& entryName);
-    std::expected<CompileResult, Error> Compile(const std::string& path, const std::string& entryName);
+                                                          const std::string& entryName);
+    std::expected<CompileResult, Error> Compile(const std::string& path,
+                                                const std::string& entryName);
+
   private:
-    SlangCompiler(Slang::ComPtr<slang::IGlobalSession> globalSession, std::vector<std::string> paths);
+    SlangCompiler(Slang::ComPtr<slang::IGlobalSession> globalSession,
+                  std::vector<std::string> paths);
     std::expected<CompileResult, Error> CompileInternal(slang::IComponentType* composedProgram,
-                                                     CompilationContext& context);
+                                                        CompilationContext& context);
     std::expected<Slang::ComPtr<slang::ISession>, Error> CreateSession();
 
     std::vector<std::string> m_paths;

--- a/shader/main.cpp
+++ b/shader/main.cpp
@@ -17,8 +17,6 @@ void PrintUsage() {
         "<include_path>...]");
 }
 
-
-
 int main(int argc, char** argv) {
     if (argc < 5) {
         PrintUsage();
@@ -42,7 +40,7 @@ int main(int argc, char** argv) {
         }
     }
 
-    if (inputPath.empty() || entryPoint.empty() || outputPath.empty()) {
+    if (inputPath.empty() || outputPath.empty()) {
         std::println(stderr, "Error: Missing required arguent");
         PrintUsage();
         return 1;
@@ -58,8 +56,13 @@ int main(int argc, char** argv) {
     SlangCompiler compiler = compilerOrError.value();
 
     std::println("Compiling {} ({}) ...", inputPath.string(), entryPoint);
-
-    auto resultOrError = compiler.Compile(inputPath.string(), std::string(entryPoint));
+    auto resultOrError = [&]() {
+        if (entryPoint.empty()) {
+            return compiler.Compile(inputPath.string());
+        } else {
+            return compiler.Compile(inputPath.string(), std::string(entryPoint));
+        }
+    }();
     if (!resultOrError.has_value()) {
         std::println(stderr, "Error! Compilation failed {}({}): {}", inputPath.string(), entryPoint,
                      resultOrError.error().message);

--- a/shader/main.cpp
+++ b/shader/main.cpp
@@ -1,9 +1,10 @@
 #include <filesystem>
 #include <fstream>
 #include <print>
-#include <string>
 #include <ranges>
+#include <string>
 #include "SlangCompiler.h"
+#include "util.h"
 
 namespace fs = std::filesystem;
 using sa = core::ShaderAssetFormat;
@@ -12,33 +13,11 @@ using namespace slangCompiler;
 
 void PrintUsage() {
     std::println(
-        "Usage: shader_baker -i <input_file> -e <entry_point> -o <output_file> [-I <include_path>...]");
+        "Usage: shader_baker -i <input_file> -e <entry_point> -o <output_file> [-I "
+        "<include_path>...]");
 }
 
-bool WriteAssetToFile(const fs::path& outputPath, const CompileResult& result) {
-    std::ofstream file(outputPath, std::ios::binary);
-    if (!file.is_open()) {
-        std::println(stderr, "Error: Failed to open output file: {}", outputPath.string());
-        return false;
-    }
 
-    file.write(reinterpret_cast<const char*>(&result.header), sizeof(sa::Header));
-
-    if (!result.bindings.empty())
-    {
-        file.write(reinterpret_cast<const char*>(result.bindings.data()),
-                   sizeof(sa::Binding) * result.bindings.size());
-    }
-
-    if (!result.sourceBlob.empty())
-    {
-        file.write(reinterpret_cast<const char*>(result.sourceBlob.data()),
-                   result.sourceBlob.size());
-    }
-
-    file.close();
-    return true;
-}
 
 int main(int argc, char** argv) {
     if (argc < 5) {
@@ -69,7 +48,6 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-
     SlangCompilerDesc desc{.paths = includePaths};
     auto compilerOrError = SlangCompiler::Create(desc);
     if (!compilerOrError.has_value()) {
@@ -96,8 +74,6 @@ int main(int argc, char** argv) {
 
     if (WriteAssetToFile(outputPath, compileResult)) {
         std::println("Succsfully baked: {}", outputPath.string());
-        std::println(" - Bindings: {}", compileResult.header.bindingCount);
-        std::println(" - Code size: {}", compileResult.header.shaderSize);
         return 0;
     } else {
         return 1;

--- a/shader/test/ParameterTest.cpp
+++ b/shader/test/ParameterTest.cpp
@@ -1,0 +1,280 @@
+#include <gtest/gtest.h>
+#include <array>
+#include <source_location>
+
+#include "SlangCompiler.h"
+
+using namespace slangCompiler;
+
+using sa = core::ShaderAssetFormat;
+
+class ParameterTest : public testing::Test {
+  protected:
+    static std::expected<SlangCompiler, Error> compiler;
+
+    static void SetUpTestSuite() {
+        // Slang session to include ShaderInterop.h Desc should append current dir to searchPath.
+        const auto loc = std::source_location::current();
+        const std::filesystem::path fullPath(loc.file_name());
+        const std::filesystem::path dirPath = fullPath.parent_path();
+
+        std::vector<std::filesystem::path> path = {dirPath};
+        const SlangCompilerDesc desc{.paths = path};
+        compiler = SlangCompiler::Create(desc);
+        ASSERT_TRUE(compiler.has_value());
+    }
+};
+
+std::expected<SlangCompiler, Error> ParameterTest::compiler = std::unexpected(Error{});
+
+const char* kParameter = R"(
+
+
+struct Material
+{
+    int albedoTextureIndex;
+    int normalTextureIndex;
+}
+
+struct Scene
+{
+    StructuredBuffer<Material> materials;
+    Texture2D textures[128];
+}
+
+struct Camera
+{
+    float4x4 mvp;
+}
+
+ParameterBlock<Scene> scene;
+ConstantBuffer<Camera> camera;
+SamplerState samplerState;
+
+struct VOut
+{
+    float4 position : SV_Position;
+    float3 normal;
+    float2 uv;
+}
+
+[shader("vertex")]
+VOut vertexMain(
+    float3 position,
+    float3 normal,
+    float2 uv
+)
+{
+    VOut output;
+    output.position = mul(camera.mvp, float4(position, 1.0));
+    output.normal = normal;
+    output.uv = uv;
+    return output;
+}
+
+[shader("fragment")]
+float4 fragmentMain(VOut input) : SV_Target
+{
+    let texture = scene.textures[scene.materials[0].albedoTextureIndex];
+    let color = texture.Sample(samplerState, input.uv);
+    return color;
+}
+
+)";
+
+const uint32_t kParameterCount = 3;
+const std::array<std::string, kParameterCount> kNameTable = {"position", "normal", "uv"};
+const std::array<sa::ShaderParameter, kParameterCount> kExpectedInputParameters = {
+    sa::ShaderParameter{
+        .variable =
+            sa::Variable{
+                .kind = sa::Kind::Vector,
+                .scalarType = sa::ScalarType::F32,
+                .shape = sa::Shape::Vector(3),
+                .nameIdx = 0,
+            },
+        .location = 0,
+        .semanticNameIdx = ~0u,
+    },
+    sa::ShaderParameter{
+        .variable =
+            sa::Variable{
+                .kind = sa::Kind::Vector,
+                .scalarType = sa::ScalarType::F32,
+                .shape = sa::Shape::Vector(3),
+                .nameIdx = 1,
+            },
+        .location = 1,
+        .semanticNameIdx = ~0u,
+    },
+    sa::ShaderParameter{
+        .variable =
+            sa::Variable{
+                .kind = sa::Kind::Vector,
+                .scalarType = sa::ScalarType::F32,
+                .shape = sa::Shape::Vector(2),
+                .nameIdx = 2,
+            },
+        .location = 2,
+        .semanticNameIdx = ~0u,
+    },
+};
+
+TEST_F(ParameterTest, ExtractsVertexInputsFromStruct) {
+    const auto result = compiler->CompileFromString(kParameter);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    CompileResult shdr = result.value();
+
+    ASSERT_EQ(shdr.entryPoints.size(), 2);
+    const sa::EntryPoint& vertexEntry = shdr.entryPoints[0];
+    ASSERT_EQ(shdr.nameTable[vertexEntry.nameIdx], "vertexMain");
+    ASSERT_EQ(vertexEntry.ioCount, kParameterCount);
+    for (uint32_t i = 0; i < kParameterCount; ++i) {
+        uint32_t paramIdx = shdr.indices[vertexEntry.ioStartIndex + i];
+        const sa::ShaderParameter actual = shdr.parameters[paramIdx];
+        const sa::ShaderParameter expected = kExpectedInputParameters[i];
+        EXPECT_EQ(actual.location, expected.location);
+        EXPECT_EQ(actual.semanticNameIdx, expected.semanticNameIdx);
+        EXPECT_EQ(actual.variable.shape.vector.length, expected.variable.shape.vector.length);
+        EXPECT_EQ(actual.variable.scalarType, expected.variable.scalarType);
+        EXPECT_EQ(actual.variable.kind, expected.variable.kind);
+        ASSERT_LT(actual.variable.nameIdx, shdr.nameTable.size());
+        EXPECT_EQ(shdr.nameTable[actual.variable.nameIdx], kNameTable[expected.variable.nameIdx]);
+    }
+
+    const sa::EntryPoint& fragmnetEntry = shdr.entryPoints[1];
+    ASSERT_EQ(shdr.nameTable[fragmnetEntry.nameIdx], "fragmentMain");
+    ASSERT_EQ(fragmnetEntry.ioCount, 1);
+}
+
+const char* kStructParameter = R"(
+struct Vertex {
+    float3 position;
+    float3 normal;
+    float2 uv;
+}
+
+struct Material {
+    int albedoTextureIndex;
+    int normalTextureIndex;
+}
+
+struct Scene {
+    StructuredBuffer<Material> materials;
+    Texture2D textures[128];
+}
+
+struct Camera {
+    float4x4 mvp;
+}
+
+ParameterBlock<Scene>
+    scene;
+ConstantBuffer<Camera> camera;
+SamplerState samplerState;
+
+struct VOut {
+    float4 position : SV_Position;
+    float3 normal;
+    float2 uv;
+}
+
+    [shader("vertex")] VOut
+    vertexMain(Vertex input, uint32_t ddd: SV_InstanceID) {
+    VOut output;
+    output.position = mul(camera.mvp, float4(input.position, 1.0));
+    output.normal = input.normal;
+    output.uv = input.uv;
+    return output;
+}
+
+[shader("fragment")] float4 fragmentMain(VOut input) : SV_Target {
+    let texture = scene.textures[scene.materials[0].albedoTextureIndex];
+    let color = texture.Sample(samplerState, input.uv);
+    return color;
+}
+)";
+
+const uint32_t kStructParameterCount = 4;
+const std::array<std::string, 5> kStructNameTable = {"input.position", "input.normal", "input.uv",
+                                                     "ddd", "SV_INSTANCEID"};
+const std::array<sa::ShaderParameter, kStructParameterCount> kExpectedStructInputParameters = {
+    sa::ShaderParameter{
+        .variable =
+            sa::Variable{
+                .kind = sa::Kind::Vector,
+                .scalarType = sa::ScalarType::F32,
+                .shape = sa::Shape::Vector(3),
+                .nameIdx = 0,
+            },
+        .location = 0,
+        .semanticNameIdx = ~0u,
+    },
+    sa::ShaderParameter{
+        .variable =
+            sa::Variable{
+                .kind = sa::Kind::Vector,
+                .scalarType = sa::ScalarType::F32,
+                .shape = sa::Shape::Vector(3),
+                .nameIdx = 1,
+            },
+        .location = 1,
+        .semanticNameIdx = ~0u,
+    },
+    sa::ShaderParameter{
+        .variable =
+            sa::Variable{
+                .kind = sa::Kind::Vector,
+                .scalarType = sa::ScalarType::F32,
+                .shape = sa::Shape::Vector(2),
+                .nameIdx = 2,
+            },
+        .location = 2,
+        .semanticNameIdx = ~0u,
+    },
+    sa::ShaderParameter{
+        .variable =
+            sa::Variable{
+                .kind = sa::Kind::Scalar,
+                .scalarType = sa::ScalarType::U32,
+                .shape = sa::Shape::Scalar(),
+                .nameIdx = 3,
+            },
+        .location = 0,
+        .semanticNameIdx = 4,
+    },
+};
+
+TEST_F(ParameterTest, ExtractsStructInputsFromStruct) {
+    const auto result = compiler->CompileFromString(kStructParameter);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    CompileResult shdr = result.value();
+
+    ASSERT_EQ(shdr.entryPoints.size(), 2);
+    const sa::EntryPoint& vertexEntry = shdr.entryPoints[0];
+    ASSERT_EQ(shdr.nameTable[vertexEntry.nameIdx], "vertexMain");
+    ASSERT_EQ(vertexEntry.ioCount, kStructParameterCount);
+    for (uint32_t i = 0; i < kStructParameterCount; ++i) {
+        uint32_t paramIdx = shdr.indices[vertexEntry.ioStartIndex + i];
+        const sa::ShaderParameter actual = shdr.parameters[paramIdx];
+        const sa::ShaderParameter expected = kExpectedStructInputParameters[i];
+        EXPECT_EQ(actual.location, expected.location);
+        EXPECT_EQ(actual.variable.shape.vector.length, expected.variable.shape.vector.length);
+        EXPECT_EQ(actual.variable.scalarType, expected.variable.scalarType);
+        EXPECT_EQ(actual.variable.kind, expected.variable.kind);
+        ASSERT_LT(actual.variable.nameIdx, shdr.nameTable.size());
+        EXPECT_EQ(shdr.nameTable[actual.variable.nameIdx],
+                  kStructNameTable[expected.variable.nameIdx]);
+        if (actual.semanticNameIdx < shdr.nameTable.size())
+        {
+            EXPECT_EQ(shdr.nameTable[actual.semanticNameIdx],
+                      kStructNameTable[expected.semanticNameIdx]);
+        }
+    }
+
+    const sa::EntryPoint& fragmnetEntry = shdr.entryPoints[1];
+    ASSERT_EQ(shdr.nameTable[fragmnetEntry.nameIdx], "fragmentMain");
+    ASSERT_EQ(fragmnetEntry.ioCount, 1);
+}

--- a/shader/test/ParameterTest.h
+++ b/shader/test/ParameterTest.h
@@ -1,0 +1,3 @@
+#include <array>
+
+#include <ShaderAssetFormat.h>

--- a/shader/test/test.cpp
+++ b/shader/test/test.cpp
@@ -2,16 +2,19 @@
 #include <slang-com-ptr.h>
 #include <slang.h>
 #include <filesystem>
+#include <fstream>
 #include <print>
 #include <source_location>
 #include "SlangCompiler.h"
 
 #include "ShaderInterop.h"
 #include "test.h"
+#include "util.h"
 
 using namespace slangCompiler;
 
 using sa = core::ShaderAssetFormat;
+namespace fs = std::filesystem;
 
 class SlangCompilerTest : public testing::Test {
   protected:
@@ -20,13 +23,33 @@ class SlangCompilerTest : public testing::Test {
     static void SetUpTestSuite() {
         // Slang session to include ShaderInterop.h Desc should append current dir to searchPath.
         const auto loc = std::source_location::current();
-        const std::filesystem::path fullPath(loc.file_name());
-        const std::filesystem::path dirPath = fullPath.parent_path();
+        const fs::path fullPath(loc.file_name());
+        const fs::path dirPath = fullPath.parent_path();
 
         std::vector<std::filesystem::path> path = {dirPath};
         const SlangCompilerDesc desc{.paths = path};
         compiler = SlangCompiler::Create(desc);
         ASSERT_TRUE(compiler.has_value());
+    }
+};
+
+class SlangCompilerIOTest : public SlangCompilerTest {
+  protected:
+    const std::string test_filepath = "test_config_output.txt";
+
+    void SetUp() override {
+        // Ensure a clean state before the test starts
+        if (fs::exists(test_filepath)) {
+            fs::remove(test_filepath);
+        }
+    }
+
+    // Runs after every TEST_F
+    void TearDown() override {
+        // Clean up the generated file so we don't pollute the filesystem
+        if (fs::exists(test_filepath)) {
+            fs::remove(test_filepath);
+        }
     }
 };
 
@@ -46,22 +69,37 @@ TEST_F(SlangCompilerTest, NoBinding) {
     ASSERT_TRUE(result.has_value()) << result.error().message;
 
     CompileResult shrd = result.value();
-    EXPECT_EQ(shrd.header.magicNumber, core::ShaderAssetFormat::SHADER_ASSET_MAGIC);
-    EXPECT_EQ(shrd.header.bindingCount, kExpectedNoBindBindingNum);
     EXPECT_EQ(shrd.bindings.size(), kExpectedNoBindBindingNum);
 }
 
-TEST_F(SlangCompilerTest, DebugCodeCompilation) {
+TEST_F(SlangCompilerTest, DebugCodeCompilationWithEntry) {
     auto result = compiler->CompileFromString(kDebugCode, "vertexMain");
     ASSERT_TRUE(result.has_value()) << result.error().message;
 
     CompileResult shrd = result.value();
-    EXPECT_EQ(shrd.header.magicNumber, core::ShaderAssetFormat::SHADER_ASSET_MAGIC);
-    ASSERT_EQ(shrd.header.bindingCount, kDebugCodeExpectedBindingNumber);
-    EXPECT_EQ(shrd.header.bindingCount, shrd.bindings.size());
+    EXPECT_EQ(shrd.entryPoints.size(), 1);
+    ASSERT_EQ(shrd.bindings.size(), kDebugCodeExpectedBindingNumber);
 
     auto binding = shrd.bindings[0];
 
+    EXPECT_EQ(binding.binding, 0);
+    EXPECT_EQ(binding.resourceType, sa::ResourceType::UniformBuffer);
+    EXPECT_EQ(binding.resource.buffer.bufferSize, kDebugCodeExpectedUniformsBufferSize);
+}
+
+TEST_F(SlangCompilerTest, DebugCodeCompilation) {
+    auto result = compiler->CompileFromString(kDebugCode);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    const CompileResult shrd = result.value();
+    ASSERT_EQ(shrd.entryPoints.size(), 2);
+    ASSERT_EQ(shrd.nameTable[shrd.entryPoints[0].nameIdx], "vertexMain");
+    ASSERT_EQ(shrd.nameTable[shrd.entryPoints[1].nameIdx], "fragmentMain");
+
+    const sa::EntryPoint& ve = shrd.entryPoints[0];
+    ASSERT_EQ(ve.bindingCount, 1);
+
+    const sa::Binding& binding = shrd.bindings[shrd.indices[ve.bindingStartIndex]];
     EXPECT_EQ(binding.binding, 0);
     EXPECT_EQ(binding.resourceType, sa::ResourceType::UniformBuffer);
     EXPECT_EQ(binding.resource.buffer.bufferSize, kDebugCodeExpectedUniformsBufferSize);
@@ -72,7 +110,7 @@ TEST_F(SlangCompilerTest, ThreeTextureInOneStruct) {
     ASSERT_TRUE(result.has_value()) << result.error().message;
 
     CompileResult shrd = result.value();
-    EXPECT_EQ(shrd.header.bindingCount, 3);
+    EXPECT_EQ(shrd.bindings.size(), 3);
     for (uint32_t i = 0; i < shrd.bindings.size(); ++i) {
         const auto& binding = shrd.bindings[i];
         EXPECT_EQ(binding.binding, i);
@@ -85,7 +123,7 @@ TEST_F(SlangCompilerTest, ParameterBlock) {
     ASSERT_TRUE(result.has_value()) << result.error().message;
 
     CompileResult shrd = result.value();
-    EXPECT_EQ(shrd.header.bindingCount, kParameterBlockExpectedBindingSize);
+    EXPECT_EQ(shrd.bindings.size(), kParameterBlockExpectedBindingSize);
     for (uint32_t i = 0; i < shrd.bindings.size(); ++i) {
         const auto& binding = shrd.bindings[i];
         const auto& expected = kParameterBlockExpectedResourceTypes[i];
@@ -101,14 +139,15 @@ TEST_F(SlangCompilerTest, ComplexTest) {
 
     CompileResult shrd = result.value();
     std::println("{}", shrd.warning);
-    EXPECT_EQ(shrd.header.bindingCount, kComplexTestExpectedBindingSize);
+    EXPECT_EQ(shrd.bindings.size(), kComplexTestExpectedBindingSize);
     for (uint32_t i = 0; i < shrd.bindings.size(); ++i) {
         const auto& actual = shrd.bindings[i];
         const auto& expected = kComplexTestExpectedBindings[i];
-        EXPECT_EQ(actual.set, expected.set)
-            << "\033[32m" << actual.name << "\033[0m set number should be " << expected.set;
+        EXPECT_EQ(actual.set, expected.set) << "\033[32m" << shrd.nameTable[actual.nameIdx]
+                                            << "\033[0m set number should be " << expected.set;
         EXPECT_EQ(actual.binding, expected.binding)
-            << "\033[32m" << actual.name << "\033[0m binding number should be " << expected.binding;
+            << "\033[32m" << shrd.nameTable[actual.nameIdx] << "\033[0m binding number should be "
+            << expected.binding;
         ASSERT_EQ(actual.resourceType, expected.resourceType);
         if (actual.resourceType == sa::ResourceType::UniformBuffer) {
             EXPECT_EQ(actual.resource.buffer.bufferSize, expected.resource.buffer.bufferSize);
@@ -116,23 +155,87 @@ TEST_F(SlangCompilerTest, ComplexTest) {
     }
 }
 
-TEST_F(SlangCompilerTest, StardardPBR) {
-    auto result = compiler->CompileFromString(kStandardPBR_VS_Data, "vertexMain");
+TEST_F(SlangCompilerTest, StandardPBRWithEntry) {
+    auto result = compiler->CompileFromString(kStandardPBR_Data, "vertexMain");
     ASSERT_TRUE(result.has_value()) << result.error().message;
 
     CompileResult shrd = result.value();
     std::println("{}", shrd.warning);
-    EXPECT_EQ(shrd.header.bindingCount, kStandardPBR_VS_ExpectedBindingSize);
+    EXPECT_EQ(shrd.bindings.size(), kStandardPBR_ExpectedBindingSize);
     for (uint32_t i = 0; i < shrd.bindings.size(); ++i) {
         const auto& actual = shrd.bindings[i];
-        const auto& expected = kStandardPBR_VS_ExpectedBindings[i];
-        EXPECT_EQ(actual.set, expected.set)
-            << "\033[32m" << actual.name << "\033[0m set number should be " << expected.set;
+        const auto& expected = kStandardPBR_ExpectedBindings[i];
+
+        EXPECT_EQ(actual.set, expected.set) << "\033[32m" << shrd.nameTable[actual.nameIdx]
+                                            << "\033[0m set number should be " << expected.set;
         EXPECT_EQ(actual.binding, expected.binding)
-            << "\033[32m" << actual.name << "\033[0m binding number should be " << expected.binding;
+            << "\033[32m" << shrd.nameTable[actual.nameIdx] << "\033[0m binding number should be "
+            << expected.binding;
         ASSERT_EQ(actual.resourceType, expected.resourceType);
         if (actual.resourceType == sa::ResourceType::UniformBuffer) {
             EXPECT_EQ(actual.resource.buffer.bufferSize, expected.resource.buffer.bufferSize);
+        }
+    }
+}
+
+auto MakeNameFinder(std::vector<std::string>& nameTable) {
+    return
+        [&nameTable](const auto& entity) -> std::string_view { return nameTable[entity.nameIdx]; };
+}
+
+TEST_F(SlangCompilerIOTest, StandardPBR) {
+    auto result = compiler->CompileFromString(kStandardPBR_Data);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    WriteAssetToFile(test_filepath, result.value());
+    // TODO!(Sunghyun;2026-03-18; move test to root and verify load function)
+}
+
+TEST_F(SlangCompilerTest, StandardPBR) {
+    auto result = compiler->CompileFromString(kStandardPBR_Data);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    CompileResult shdr = result.value();
+    std::println("{}", shdr.warning);
+    ASSERT_EQ(shdr.entryPoints.size(), 2);
+    auto getShdrNames = MakeNameFinder(shdr.nameTable);
+    ASSERT_EQ(getShdrNames(shdr.entryPoints[0]), "vertexMain");
+    ASSERT_EQ(getShdrNames(shdr.entryPoints[1]), "fragmentMain");
+
+    const sa::EntryPoint& ve = shdr.entryPoints[0];
+    {
+        ASSERT_EQ(ve.bindingCount, kStandardPBR_ExpectedBindingsSize_VS);
+        for (uint32_t i = 0; i < ve.bindingCount; ++i) {
+            const auto& actual = shdr.bindings[shdr.indices[ve.bindingStartIndex + i]];
+            const auto& expected = kStandardPBR_ExpectedBindings_VS[i];
+
+            EXPECT_EQ(actual.set, expected.set) << "\033[32m" << shdr.nameTable[actual.nameIdx]
+                                                << "\033[0m set number should be " << expected.set;
+            EXPECT_EQ(actual.binding, expected.binding)
+                << "\033[32m" << getShdrNames(actual) << "\033[0m binding number should be "
+                << expected.binding;
+            ASSERT_EQ(actual.resourceType, expected.resourceType);
+            if (actual.resourceType == sa::ResourceType::UniformBuffer) {
+                EXPECT_EQ(actual.resource.buffer.bufferSize, expected.resource.buffer.bufferSize);
+            }
+        }
+    }
+    const sa::EntryPoint& fe = shdr.entryPoints[1];
+    {
+        ASSERT_EQ(fe.bindingCount, 2);
+        for (uint32_t i = 0; i < fe.bindingCount; ++i) {
+            const auto& actual = shdr.bindings[shdr.indices[fe.bindingStartIndex + i]];
+            const auto& expected = kStandardPBR_ExpectedBindings_FS[i];
+
+            EXPECT_EQ(actual.set, expected.set) << "\033[32m" << shdr.nameTable[actual.nameIdx]
+                                                << "\033[0m set number should be " << expected.set;
+            EXPECT_EQ(actual.binding, expected.binding)
+                << "\033[32m" << getShdrNames(actual) << "\033[0m binding number should be "
+                << expected.binding;
+            ASSERT_EQ(actual.resourceType, expected.resourceType);
+            if (actual.resourceType == sa::ResourceType::UniformBuffer) {
+                EXPECT_EQ(actual.resource.buffer.bufferSize, expected.resource.buffer.bufferSize);
+            }
         }
     }
 }

--- a/shader/test/test.h
+++ b/shader/test/test.h
@@ -87,7 +87,7 @@ struct Fragment {
 // Vertex  Shader
 struct VertexStageOutput {
     CoarseVertex coarseVertex : CoarseVertex;
-    float4 sv_position : SV_Position;
+    float4 sv_position : SV_Position;   
 };
 
 [shader("vertex")]
@@ -176,8 +176,8 @@ const std::array<core::ShaderAssetFormat::Binding, kComplexTestExpectedBindingSi
             // cbuffer PerFrameUniforms
             .set = 0,
             .binding = 0,
-            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
             .resource = core::ShaderAssetFormat::Resource::Buffer(80),
+            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
         },
         core::ShaderAssetFormat::Binding{
             // TextureSet gExtraTextures : register(space0) .albedoMap
@@ -195,8 +195,8 @@ const std::array<core::ShaderAssetFormat::Binding, kComplexTestExpectedBindingSi
             // ParameterBlock<MaterialData> gMaterial : register(space1) auto generated Uniform
             .set = 1,
             .binding = 0,
-            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
             .resource = core::ShaderAssetFormat::Resource::Buffer(16),
+            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
         },
         core::ShaderAssetFormat::Binding{
             // ParameterBlock<MaterialData> gMaterial : register(space1) .textures.albedoMap
@@ -270,14 +270,14 @@ float4 vertexMain(AssembledVertex vertex) : SV_Position {
 }
 )";
 
-const uint32_t kStandardPBR_VS_ExpectedBindingSize = 4;
-const std::array<core::ShaderAssetFormat::Binding, kStandardPBR_VS_ExpectedBindingSize>
-    kStandardPBR_VS_ExpectedBindings{
+const uint32_t kStandardPBR_ExpectedBindingSize = 4;
+const std::array<core::ShaderAssetFormat::Binding, kStandardPBR_ExpectedBindingSize>
+    kStandardPBR_ExpectedBindings{
         core::ShaderAssetFormat::Binding{
             .set = 0,
             .binding = 0,
-            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
             .resource = core::ShaderAssetFormat::Resource::Buffer(64),
+            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
         },
         core::ShaderAssetFormat::Binding{
             .set = 1,
@@ -292,12 +292,38 @@ const std::array<core::ShaderAssetFormat::Binding, kStandardPBR_VS_ExpectedBindi
         core::ShaderAssetFormat::Binding{
             .set = 2,
             .binding = 0,
-            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
             .resource = core::ShaderAssetFormat::Resource::Buffer(64),
+            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
+        },
+    };
+const uint32_t kStandardPBR_ExpectedBindingsSize_VS = 1;
+const std::array<core::ShaderAssetFormat::Binding, kStandardPBR_ExpectedBindingsSize_VS>
+    kStandardPBR_ExpectedBindings_VS{
+        core::ShaderAssetFormat::Binding{
+            .set = 0,
+            .binding = 0,
+            .resource = core::ShaderAssetFormat::Resource::Buffer(64),
+            .resourceType = core::ShaderAssetFormat::ResourceType::UniformBuffer,
         },
     };
 
-const char* kStandardPBR_VS_Data = R"(
+const uint32_t kStandardPBR_ExpectedBindingsSize_FS = 2;
+const std::array<core::ShaderAssetFormat::Binding, kStandardPBR_ExpectedBindingsSize_FS>
+    kStandardPBR_ExpectedBindings_FS{
+        core::ShaderAssetFormat::Binding{
+            .set = 1,
+            .binding = 0,
+            .resourceType = core::ShaderAssetFormat::ResourceType::Texture,
+        },
+        core::ShaderAssetFormat::Binding{
+            .set = 1,
+            .binding = 1,
+            .resourceType = core::ShaderAssetFormat::ResourceType::Sampler,
+        },
+
+    };
+
+const char* kStandardPBR_Data = R"(
 #include <ShaderInterop.h>
 
 [[vk::binding(0, BindSlot::Global)]]

--- a/shader/util.cpp
+++ b/shader/util.cpp
@@ -54,11 +54,14 @@ bool WriteAssetToFile(const fs::path& outputPath, const CompileResult& result) {
 
     if (!result.nameTable.empty()) {
         header.nameTableOffset = file.tellp();
+        uint32_t size = 0;
         for (const auto& name : result.nameTable) {
             std::string_view nameView = name;
             file.write(nameView.data(), nameView.size());
             file.put('\0');
+            size += nameView.size() + 1;
         }
+        header.nameTableSize = size;
     }
 
 

--- a/shader/util.cpp
+++ b/shader/util.cpp
@@ -1,0 +1,70 @@
+#include "util.h"
+#include <fstream>
+#include <print>
+
+namespace fs = std::filesystem;
+using namespace slangCompiler;
+using sa = core::ShaderAssetFormat;
+
+bool WriteAssetToFile(const fs::path& outputPath, const CompileResult& result) {
+    std::ofstream file(outputPath, std::ios::binary);
+    if (!file.is_open()) {
+        std::println(stderr, "Error: Failed to open output file: {}", outputPath.string());
+        return false;
+    }
+    sa::Header header;
+    header.parameterCount = static_cast<uint16_t>(result.parameters.size());
+    header.bindingCount = static_cast<uint16_t>(result.bindings.size());
+    header.variableCount = static_cast<uint16_t>(result.variables.size());
+    header.entryPointCount = static_cast<uint16_t>(result.entryPoints.size());
+    header.shaderSize = static_cast<uint32_t>(result.sourceBlob.size());
+    header.indexCount = static_cast<uint16_t>(result.indices.size());
+    file.write(reinterpret_cast<const char*>(&header), sizeof(sa::Header));
+
+    if (!result.parameters.empty()) {
+        header.parameterOffset = file.tellp();
+        file.write(reinterpret_cast<const char*>(result.parameters.data()),
+                   sizeof(sa::ShaderParameter) * result.parameters.size());
+    }
+    if (!result.bindings.empty()) {
+        header.bindingOffset = file.tellp();
+        file.write(reinterpret_cast<const char*>(result.bindings.data()),
+                   sizeof(sa::Binding) * result.bindings.size());
+    }
+    if (!result.variables.empty()) {
+        header.variableOffset = file.tellp();
+        file.write(reinterpret_cast<const char*>(result.variables.data()),
+                   sizeof(sa::Variable) * result.variables.size());
+    }
+    if (!result.entryPoints.empty()) {
+        header.entryPointOffset = file.tellp();
+        file.write(reinterpret_cast<const char*>(result.entryPoints.data()),
+                   sizeof(sa::EntryPoint) * result.entryPoints.size());
+    }
+    if (!result.sourceBlob.empty()) {
+        header.shaderOffset = file.tellp();
+        file.write(reinterpret_cast<const char*>(result.sourceBlob.data()),
+                   result.sourceBlob.size());
+    }
+    if (!result.indices.empty()) {
+        header.indexOffset = file.tellp();
+        file.write(reinterpret_cast<const char*>(result.indices.data()),
+                        result.indices.size());
+    }
+
+    if (!result.nameTable.empty()) {
+        header.nameTableOffset = file.tellp();
+        for (const auto& name : result.nameTable) {
+            std::string_view nameView = name;
+            file.write(nameView.data(), nameView.size());
+            file.put('\0');
+        }
+    }
+
+
+    file.seekp(0);
+    file.write(reinterpret_cast<const char*>(&header), sizeof(sa::Header));
+
+    file.close();
+    return true;
+}

--- a/shader/util.h
+++ b/shader/util.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <filesystem>
+#include "SlangCompiler.h"
+
+bool WriteAssetToFile(const std::filesystem::path& outputPath,
+                      const slangCompiler::CompileResult& result);


### PR DESCRIPTION
# Overview
This PR transitions the rendering pipeline to a fully data-driven architecture by decoupling vertex layouts from hardcoded C++ types and introducing a dynamic resolution system. 

It also brings a massive overhaul to the `ShaderAssetFormat` and the Slang compiler toolchain to support multi-entry-point compilation and precise semantic matching.

# Issue #4 Acceptance Criteria CheckList

* [x] **Decouple monolithic `Vertex` struct:** Resolved. Replaced with dynamic multi-stream layouts (`Position` in Slot 0, `Surface` in Slot 1).
* [x] **Support binding multiple vertex buffers:** Resolved. Pipeline layout configuration and RenderGraph updated for multi-binding.
* [x] **Implement optional `Color` stream & demonstrate rendering:** Resolved. The parsing and pipeline variant generation are fully implemented.
* [ ] **Verify depth-only passes bind only Stream 0:** **[Deferred / Out of Scope]** The structural foundation is complete, but the actual Depth Pre-pass / Shadow pass logic will be implemented in a follow-up PR. I will open a separate tracking issue for this verification.

# Key Architectural Changes

1. **Dynamic Vertex Streams & Mediator Pattern:**
   - Replaced the hardcoded `struct Vertex` with `MeshVertexState`.
   - `Mesh` now dynamically packs only the available attributes (Position, Normal, UV, Color) into flat `std::byte` arrays, saving VRAM.
   - The `Material` class now acts as a Mediator (`GetPipelineDesc`), inspecting the `MeshVertexState` and its internal state to automatically resolve the correct shader entry points (e.g., `vertexMain_Color` vs `vertexMain`).

2. **ShaderAssetFormat v4 & Slang Compiler Overhaul:**
   - Redesigned the shader binary format to natively support multiple entry points within a single `.shdr` asset. Removed the legacy hack of merging VS and FS blobs.
   - The Slang compiler now deeply reflects IO parameters, extracting semantic indices and variable layouts, and deduplicates strings using a centralized `nameTable` (String Pool) to minimize memory footprint.

3. **VertexLayoutManager (Flyweight Caching):**
   - Introduced `VertexLayoutManager` to pool and cache `wgpu::VertexBufferLayout` descriptors. This guarantees pointer safety for the downstream WebGPU C-API and prevents the overhead of regenerating descriptors per submesh.

4. **Testing Framework:**
   - Added extensive unit tests (`ParameterTest.cpp`) to strictly validate the Slang reflection tree and parameter extraction logic.

# Impact
Ultimately, this PR achieves substantial memory efficiency and pipeline flexibility. The engine can now gracefully handle various glTF meshes (with or without vertex colors) and dynamically match them to the optimal shader permutation without any gameplay code intervention.

# Technical Debt & Future Work

- **Flexibility (Shader Permutations):** Currently, `Material::GetPipelineDesc` relies on hardcoded entry point strings. This will be resolved in the future by introducing engine-defined Slang generics and exposing core shader modules to handle permutations elegantly.
- **Performance (PSO Pre-warming):** Standard mesh formats (like glTF) inherently contain material indices, but our current `MeshAssetFormat` does not retain this mapping. By preserving this relationship, we can shift pipeline generation (PSO pre-warming) from the runtime render loop to the asset load time, eliminating potential render hitches.
- **Pipeline Scalability (Multi-pass Rendering):** The current implementation of `Material` as a pipeline mediator is sufficient for forward rendering but lacks scalability for depth-only passes (e.g., Shadow Mapping). Refactoring this via `PassType` context injection is scheduled for a future architectural update.