### PR TITLE
[Feature] Decouple SceneRenderer and implement data-driven render queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ CMakePresets.json
 vcpkg_installed
 out
 .vs
+app/resources

--- a/app/ExampleLayer.cpp
+++ b/app/ExampleLayer.cpp
@@ -39,52 +39,23 @@ std::unique_ptr<ExampleLayer> ExampleLayer::Create(core::Application* app) {
         app->GetMeshManager(),
     };
 
+
     return std::unique_ptr<ExampleLayer>(new ExampleLayer(app, device, gameCamera, loader));
 }
 
-void ExampleLayer::OnAttach() {
+void ExampleLayer::OnAttach(core::Scene& scene) {
     auto modelOrError = m_loader.LoadModel("resources/microphone/scene.gltf");
     if (!modelOrError.has_value()) {
         std::println("failed to load");
     }
     m_modelHandle = modelOrError.value();
+    core::AssetView<core::render::Model> model = m_app->GetAssetManager()->GetModel(m_modelHandle);
+    scene.AddModel(model, glm::mat4x4(1.F));
 }
 
-void ExampleLayer::OnRender(core::render::FrameContext& context) {
-    auto am = m_app->GetAssetManager();
-    auto modelView = am->GetModel(m_modelHandle);
-    auto pm = m_app->GetPipelineManager();
-
-    auto cameraData = m_gameCamera.GetCameraUniformData();
-    context.SetCameraData(cameraData);
-
-    for (auto& renderUnit : modelView->renderUnits) {
-        auto meshView = am->GetMesh(renderUnit.meshHandle);
-        auto& subMesh = meshView->GetSubMeshInfo(renderUnit.subMeshIndex);
-
-        auto material = am->GetMaterial(renderUnit.materialHandle);
-
-        core::render::PipelineDesc desc =
-            material->GetPipelineDesc(meshView->GetVertexState(subMesh.stateIndex));
-
-        wgpu::RenderPipeline pipeline = pm->GetRenderPipeline(desc);
-
-        core::render::RenderPacket packet{
-            .pipeline = pipeline,
-            .vertexBuffer = meshView->vertexBuffer,
-            .indexBuffer = meshView->indexBuffer,
-            .bufferRanges =
-                meshView->GetBufferRanges(subMesh.bufferRangeStart, subMesh.bufferRangeCount),
-            .indexStart = subMesh.indexStart,
-            .indexCount = subMesh.indexCount,
-            .material = material,
-        };
-        context.Submit(packet);
-    }
-}
-
-void ExampleLayer::OnUpdate() {
+void ExampleLayer::OnUpdate(core::Scene& scene) {
     m_cameraController.UpdateCamera(m_gameCamera, 0.1);
+    scene.cameraData = m_gameCamera.GetCameraUniformData();
 }
 
 bool ExampleLayer::OnEvent(core::Event& event) {

--- a/app/ExampleLayer.h
+++ b/app/ExampleLayer.h
@@ -3,8 +3,8 @@
 #include "Event.h"
 #include "Layer.h"
 #include "ModelLoader.h"
+#include "Scene.h"
 #include "ShaderAssetFormat.h"
-#include "render/render.h"
 
 #include "Camera3D.h"
 
@@ -12,9 +12,8 @@ class ExampleLayer : public core::Layer {
   public:
     static std::unique_ptr<ExampleLayer> Create(core::Application* app);
 
-    void OnAttach() override;
-    void OnRender(core::render::FrameContext& context) override;
-    void OnUpdate() override;
+    void OnAttach(core::Scene& scene) override;
+    void OnUpdate(core::Scene& scene) override;
     bool OnEvent(core::Event& event) override;
 
   private:
@@ -22,10 +21,7 @@ class ExampleLayer : public core::Layer {
                  core::render::Device* device,
                  common::GameCamera camera,
                  loader::GLTFLoader loader)
-        : m_app(app),
-          m_gameCamera(camera),
-          m_device(device),
-          m_loader(loader) {}
+        : m_app(app), m_gameCamera(camera), m_device(device), m_loader(loader) {}
 
     common::GameCamera m_gameCamera;
     common::CameraController m_cameraController;

--- a/core/Application.cpp
+++ b/core/Application.cpp
@@ -50,7 +50,7 @@ std::expected<Application, int> core::Application::Create(ApplicationSpec& spec)
         device.get(), assetManager.get(), shaderManager.get(), textureManager.get(),
         layoutCache.get());
 
-    render::RenderGraph renderGraph(device.get(), pipelineManager.get(),
+    render::RenderGraph renderGraph(device.get(), assetManager.get(), pipelineManager.get(),
                                     layoutCache->GetBindGroupLayout(globalBindGroupLayout));
 
     return Application(std::move(window), std::move(device), std::move(assetManager),
@@ -63,30 +63,29 @@ std::expected<Application, int> core::Application::Create(ApplicationSpec& spec)
 core::Application::~Application() {}
 
 void core::Application::Run() {
-    render::FrameContext frameContext;
+    render::RenderQueue renderQueue;
     while (!m_souldColose) {
         m_window.PollEvent();
         m_eventDispatcher->ProcessEvent([this](auto&& event) -> void { this->RaiseEvent(event); });
 
+        renderQueue.Clear();
         for (auto& layer : m_Layers) {
             // layer->OnUpdate(); // Assuming Layer has an OnUpdate method
-            layer->OnUpdate();
+            layer->OnUpdate(m_scene);
         }
 
-        for (auto& layer : m_Layers) {
-            layer->OnRender(frameContext);
-        }
-        m_renderGraph.Execute(frameContext);
+
+        render::SceneRenderer::ExtractRenderQueue(m_scene, renderQueue);
+        m_renderGraph.Execute(renderQueue);
         m_device->Present();
 
-        frameContext.ClearQueue();
     }
 
     glfwTerminate();
 }
 
 void core::Application::AttachLayer(std::unique_ptr<Layer> layer) {
-    layer->OnAttach();
+    layer->OnAttach(m_scene);
     m_Layers.emplace_back(std::move(layer));
 }
 

--- a/core/Application.h
+++ b/core/Application.h
@@ -5,11 +5,12 @@
 #include "AssetManager.h"
 #include "Layer.h"
 #include "Window.h"
+#include "render/MaterialManager.h"
 #include "render/MeshManager.h"
 #include "render/PipelineManager.h"
+#include "render/SceneRenderer.h"
 #include "render/ShaderManager.h"
 #include "render/TextureManager.h"
-#include "render/MaterialManager.h"
 #include "render/render.h"
 
 namespace core {
@@ -17,6 +18,7 @@ namespace core {
 struct ApplicationSpec {
     WindowSpec* winSpec;
 };
+
 class Application {
   public:
     Application() = delete;
@@ -54,7 +56,7 @@ class Application {
                 std::unique_ptr<render::PipelineManager> pipelineManager,
                 std::unique_ptr<render::ShaderManager> shaderManager,
                 std::unique_ptr<render::TextureManager> textureManager,
-                 std::unique_ptr<render::MaterialManager> materialManager,
+                std::unique_ptr<render::MaterialManager> materialManager,
                 std::unique_ptr<render::MeshManager> meshManager)
         : m_window(std::move(window)),
           m_device(std::move(device)),
@@ -81,6 +83,7 @@ class Application {
     std::unique_ptr<render::MeshManager> m_meshManager;
     render::RenderGraph m_renderGraph;
     std::unique_ptr<render::MaterialManager> m_materialManager;
+    Scene m_scene;
 
     std::vector<std::unique_ptr<Layer>> m_Layers;
     bool m_souldColose = false;

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -45,7 +45,13 @@
     "render/TextureManager.h" "render/TextureManager.cpp"
  "render/MeshManager.h"  "render/MeshManager.cpp"
  "render/Model.h"
- "render/VertexLayoutManager.h" "render/VertexLayoutManager.cpp" "wgx/types.h")
+ "render/VertexLayoutManager.h" "render/VertexLayoutManager.cpp" 
+ "wgx/types.h" 
+ "render/IRenderPass.h" 
+ "render/pass/ForwardRenderPass.h" "render/pass/ForwardRenderPass.cpp" 
+ "render/SceneRenderer.h" "render/SceneRenderer.cpp"
+ "Scene.h"
+)
 
 include (../cmake/ShaderCompiler.cmake)
 

--- a/core/Layer.h
+++ b/core/Layer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "render/RenderGraph.h"
+#include "Scene.h"
 #include "Event.h"
 
 namespace core {
@@ -9,9 +10,8 @@ class Layer {
         Layer()          = default;
         virtual ~Layer() = default;
     
-        virtual void OnAttach() = 0;
-        virtual void OnRender(render::FrameContext& context) = 0;
-        virtual void OnUpdate()   = 0;
+        virtual void OnAttach(core::Scene& scene) = 0;
+        virtual void OnUpdate(core::Scene& scene)   = 0;
         virtual bool OnEvent(Event& event) = 0;
 };
 }

--- a/core/Scene.h
+++ b/core/Scene.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "render/render.h"
+#include "render/Model.h"
+
+namespace core {
+struct Scene {
+    render::CameraUniformData cameraData;
+    std::vector<AssetView<render::Model>> models;
+    std::vector<glm::mat4x4> modelMatrices;
+
+    void AddModel(const AssetView<render::Model>& model, const glm::mat4x4& transform) {
+        models.push_back(model);
+        modelMatrices.push_back(transform);
+    }
+};
+}  // namespace core

--- a/core/import/GLTFImporter.cpp
+++ b/core/import/GLTFImporter.cpp
@@ -150,7 +150,6 @@ std::expected<GLTFImportResult, Error> GLTFImporter::ImportFromFile(const std::s
 
         result.modelAsset.nodes.push_back(modelNode);
     }
-
     return result;
 }
 

--- a/core/render/Model.h
+++ b/core/render/Model.h
@@ -12,6 +12,7 @@ struct RenderUnit {
     Handle materialHandle;
     glm::mat4 modelMatrix = glm::mat4(1.0f);
 };
+
 struct Model {
     Model() = default;
 

--- a/core/render/RenderGraph.cpp
+++ b/core/render/RenderGraph.cpp
@@ -1,10 +1,14 @@
 #include "RenderGraph.h"
 #include <array>
+#include "Material.h"
+#include "Mesh.h"
+#include "SceneRenderer.h"
 
 core::render::RenderGraph::RenderGraph(Device* device,
+                                       AssetManager* assetManager,
                                        PipelineManager* pipelineManager,
                                        const wgpu::BindGroupLayout globalBindGroupLayout)
-    : m_device(device), m_pipelineManager(pipelineManager) {
+    : m_device(device), m_assetManager(assetManager), m_pipelineManager(pipelineManager) {
     CameraUniformData cameraUniformData;
     wgpu::Buffer globalUniform = device->CreateBufferFromData(&cameraUniformData.viewProj,
                                                               sizeof(cameraUniformData.viewProj),
@@ -22,10 +26,9 @@ core::render::RenderGraph::RenderGraph(Device* device,
         .entryCount = bindGroupEntries.size(),
         .entries = bindGroupEntries.data(),
     });
-
 }
 
-void core::render::RenderGraph::Execute(FrameContext& frameContext) {
+void core::render::RenderGraph::Execute(RenderQueue& renderQueue) {
     auto d = m_device->GetDeivce();
 
     wgpu::RenderPassColorAttachment colorAttachment{
@@ -42,7 +45,7 @@ void core::render::RenderGraph::Execute(FrameContext& frameContext) {
         .depthStencilAttachment = nullptr,
     };
 
-    auto& cameraData = frameContext.GetCameraUniformData();
+    auto& cameraData = renderQueue.cameraData;
     d.GetQueue().WriteBuffer(m_globalUniformBuffer, 0, &cameraData.viewProj,
                              sizeof(cameraData.viewProj));
 
@@ -51,19 +54,29 @@ void core::render::RenderGraph::Execute(FrameContext& frameContext) {
 
     pass.SetBindGroup(0, m_globalBindGroup);
 
-    auto packets = frameContext.GetQueue();
-    for (auto& p : packets) {
-        pass.SetPipeline(p.pipeline);
-        for (uint i = 0; i < p.bufferRanges.size(); ++i) {
-            const auto bufferRange = p.bufferRanges[i];
-            pass.SetVertexBuffer(i, p.vertexBuffer, bufferRange.offset, bufferRange.size);
+    // TODO!(#2, #8; Sunghyun) beneath render logic will be replace by a RenderPass defined in
+    // issues.
+    for (uint32_t i = 0; i < renderQueue.renderIntents.size(); ++i) {
+        const auto& intent = renderQueue.renderIntents[i];
+        const auto& transform = renderQueue.transforms[intent.transformIndex];
+        AssetView<Mesh> mesh = m_assetManager->GetMesh(intent.meshHandle);
+        AssetView<Material> material = m_assetManager->GetMaterial(intent.materialHandle);
+
+        const MeshAssetFormat::SubMeshInfo& subMesh = mesh->GetSubMeshInfo(intent.subMeshIndex);
+        auto pipeline = m_pipelineManager->GetRenderPipeline(
+            material->GetPipelineDesc(mesh->GetVertexState(subMesh.stateIndex)));
+        pass.SetPipeline(pipeline);
+        std::span<const MeshAssetFormat::BufferRange> bufferRanges =
+            mesh->GetBufferRanges(subMesh.bufferRangeStart, subMesh.bufferRangeCount);
+        for (uint i = 0; i < bufferRanges.size(); ++i) {
+            const auto bufferRange = bufferRanges[i];
+            pass.SetVertexBuffer(i, mesh->vertexBuffer, bufferRange.offset, bufferRange.size);
         }
 
-        pass.SetIndexBuffer(p.indexBuffer, wgpu::IndexFormat::Uint32);
-        pass.SetBindGroup(1, p.material->GetBindGroup());
-        // pass.SetBindGroup(2, m_tempBindGroup.bindGroup);
+        pass.SetIndexBuffer(mesh->indexBuffer, wgpu::IndexFormat::Uint32);
+        pass.SetBindGroup(1, material->GetBindGroup());
 
-        pass.DrawIndexed(p.indexCount, 1, p.indexStart);
+        pass.DrawIndexed(subMesh.indexCount, 1, subMesh.indexStart);
     }
 
     pass.End();

--- a/core/render/RenderGraph.h
+++ b/core/render/RenderGraph.h
@@ -3,8 +3,10 @@
 #include <webgpu/webgpu_cpp.h>
 #include <string>
 
+#include "AssetManager.h"
 #include "render.h"
 #include "PipelineManager.h"
+#include "SceneRenderer.h"
 #include "Material.h"
 
 namespace core::render {
@@ -35,15 +37,21 @@ class FrameContext {
 class RenderGraph {
   public:
     RenderGraph(Device* device,
+                AssetManager* assetManager,
                 PipelineManager* pipelineManager,
                 const wgpu::BindGroupLayout globalBindGroupLayout);
 
     RenderGraph(RenderGraph&& rhs) = default;
 
-    void Execute(FrameContext& frameContext);
+    void Execute(RenderQueue& frameContext);
 
   private:
     Device* m_device;
+
+    AssetManager* m_assetManager;  // TODO!(#2, #8; Sunghyun) m_assetManager will be removed in
+                                   // future, and each RenderPass will directly access asset manager
+                                   // to get necessary resource. But for now, we put asset manager
+                                   // in RenderGraph for simplicity.
     PipelineManager* m_pipelineManager;
 
     wgpu::BindGroup m_globalBindGroup;

--- a/core/render/SceneRenderer.cpp
+++ b/core/render/SceneRenderer.cpp
@@ -1,0 +1,20 @@
+#include "SceneRenderer.h"
+
+void core::render::SceneRenderer::ExtractRenderQueue(const Scene& scene,
+                                                     RenderQueue& outRenderQueue) {
+    for (uint32_t i = 0; i < scene.models.size(); ++i) {
+        RenderIntent intent;
+        for (const auto& renderUnit : scene.models[i]->renderUnits) {
+            intent.meshHandle = renderUnit.meshHandle;
+            intent.subMeshIndex = renderUnit.subMeshIndex;
+            intent.materialHandle = renderUnit.materialHandle;
+            intent.transformIndex = i;
+            // SceneRenderer.cpp (Inside ExtractRenderQueue)
+            // TODO(#10): Generate sort key from Pass, Pipeline, and Material IDs.
+            intent.sortKey = 0;
+            outRenderQueue.renderIntents.push_back(intent);
+        }
+    }
+    outRenderQueue.cameraData = scene.cameraData;
+    outRenderQueue.transforms = std::span(scene.modelMatrices.data(), scene.modelMatrices.size());
+}

--- a/core/render/SceneRenderer.h
+++ b/core/render/SceneRenderer.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <span>
+#include "Scene.h"
+#include "render.h"
+
+
+namespace core::render {
+
+struct RenderIntent {
+    Handle meshHandle;
+    uint32_t subMeshIndex;
+    Handle materialHandle;
+    uint32_t transformIndex;
+    // TODO(#10): Populate 64-bit sort key for Radix Sorting
+    uint64_t sortKey = 0;
+};
+
+struct RenderQueue {
+    std::vector<RenderIntent> renderIntents;
+    std::span<const glm::mat4x4> transforms;
+    CameraUniformData cameraData;
+
+    void Clear() {
+        renderIntents.clear();
+        transforms = {};
+    }
+};
+
+class SceneRenderer {
+  public:
+    static void ExtractRenderQueue(const Scene& scene, RenderQueue& outRenderQueue);
+};
+}  // namespace core::render


### PR DESCRIPTION
# Overview
This PR fully decouples the application game logic from the WebGPU graphics backend. It establishes `SceneRenderer` as a stateless frontend extractor and introduces `RenderIntent` to facilitate lock-free, deferred resource resolution.

# Key Changes
* **Application Isolation:** Removed `FrameContext` and all `<webgpu/webgpu_cpp.h>` dependencies from `ExampleLayer`. The layer now strictly mutates `core::Scene` data.
* **Zero-Copy Architecture:** `SceneRenderer` no longer copies `glm::mat4` transforms. It passes a `std::span` of contiguous memory directly to the `RenderQueue`.
* **Lightweight Intents:** Replaced the heavyweight `RenderPacket` with `RenderIntent`, storing only asset handles and transform indices to maximize CPU cache locality.

# Out of Scope / Deferred
* **Draw Call Sorting:** The `sortKey` inside `RenderIntent` is currently stubbed with `0`. The bitwise packing logic and backend Radix Sort are explicitly deferred to **Issue #10**.

## 🔗 Related Issues
Closes #8
Blocks #10